### PR TITLE
Revert "Bump com.google.protobuf:protobuf-java from 3.25.5 to 4.31.1 in /client in the maven group across 1 directory (#215)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
              the pom file in https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/ and looking for the protobuf-java
              version in that file.
              -->
-        <protobuf.version>4.31.1</protobuf.version>
+        <protobuf.version>3.25.5</protobuf.version>
 
         <assertj.version>3.24.1</assertj.version>
         <awaitility.version>4.2.2</awaitility.version>


### PR DESCRIPTION
This reverts commit 34c9134f10cf3c8d82b58d21f441989d18468677.