### PR TITLE
fix: parse legacy LeaderHint from Oxia 0.16.x servers

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
@@ -15,6 +15,7 @@
  */
 package io.oxia.client.grpc;
 
+import static io.oxia.client.grpc.OxiaStatusCode.NODE_IS_NOT_LEADER;
 import static io.oxia.client.grpc.OxiaStatusCode.RESOURCE_UNAVAILABLE;
 import static io.oxia.client.grpc.OxiaStatusCode.SHARD_NOT_FOUND;
 import static io.oxia.client.grpc.OxiaStatusCode.TIMEOUT;
@@ -26,6 +27,7 @@ import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.oxia.client.util.CompletableFutures;
+import io.oxia.proto.LeaderHint;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
@@ -138,6 +140,28 @@ public class OxiaStatusException extends RuntimeException {
                 metadata = info.getMetadataMap();
                 break;
             } catch (InvalidProtocolBufferException ignored) {
+            }
+        }
+        // parse the legacy leader hint detail sent by Oxia servers before 0.17.0
+        if (!metadata.containsKey("leader")) {
+            for (var detail : grpcStatus.getDetailsList()) {
+                if (!detail.getTypeUrl().endsWith(".LeaderHint")) {
+                    continue;
+                }
+                try {
+                    var hint = new LeaderHint();
+                    hint.parseFrom(detail.getValue().toByteArray());
+                    if (statusCode == UNKNOWN) {
+                        statusCode = NODE_IS_NOT_LEADER;
+                    }
+                    metadata =
+                            Map.of(
+                                    "shard", Long.toString(hint.getShard()),
+                                    "leader", hint.getLeaderAddress());
+                } catch (RuntimeException ignored) {
+                    // Ignore malformed hint details
+                }
+                break;
             }
         }
         // parse from the grpc standard code

--- a/client/src/main/proto/io/streamnative/oxia/client.proto
+++ b/client/src/main/proto/io/streamnative/oxia/client.proto
@@ -127,6 +127,18 @@ message ShardAssignmentsRequest {
 }
 
 /**
+ * The hint about the current leader of a shard, returned as a detail of
+ * `node is not leader` errors by Oxia servers before 0.17.0.
+ */
+message LeaderHint {
+  // The shard id
+  int64 shard = 1;
+
+  // The current shard leader, e.g. `host:port`
+  string leader_address = 2;
+}
+
+/**
  * The response to a shard assignments request.
  */
 message ShardAssignments {

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
@@ -19,11 +19,13 @@ import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
 import com.google.rpc.ErrorInfo;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.protobuf.StatusProto;
+import io.oxia.proto.LeaderHint;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -61,6 +63,30 @@ class OxiaStatusExceptionTest {
                         Status.UNKNOWN.withDescription("node is not leader for shard 1").asRuntimeException());
 
         assertThat(error.getStatusCode()).isEqualTo(OxiaStatusCode.NODE_IS_NOT_LEADER);
+        assertThat(error.isRetryable()).isTrue();
+    }
+
+    @Test
+    void convertsLegacy016LeaderHintDetail() {
+        var leaderHint = new LeaderHint().setShard(1).setLeaderAddress("server-1:6648");
+        var grpcStatus =
+                com.google.rpc.Status.newBuilder()
+                        .setCode(Status.Code.UNKNOWN.value())
+                        .setMessage("node is not leader for shard 1")
+                        .addDetails(
+                                Any.newBuilder()
+                                        .setTypeUrl("type.googleapis.com/io.oxia.proto.v1.LeaderHint")
+                                        .setValue(ByteString.copyFrom(leaderHint.toByteArray())))
+                        .build();
+
+        var error = OxiaStatusException.from(StatusProto.toStatusRuntimeException(grpcStatus));
+
+        assertThat(error.getStatusCode()).isEqualTo(OxiaStatusCode.NODE_IS_NOT_LEADER);
+        assertThat(error.getMetadata())
+                .containsEntry("shard", "1")
+                .containsEntry("leader", "server-1:6648");
+        assertThat(error.getLeaderHint(1)).contains("server-1:6648");
+        assertThat(error.getLeaderHint(2)).isEmpty();
         assertThat(error.isRetryable()).isTrue();
     }
 


### PR DESCRIPTION
## Motivation

The Java client only reads the shard-leader redirect from `google.rpc.ErrorInfo` metadata, which Oxia servers publish from 0.17.0. Servers on the 0.16.x line (including 0.16.8) attach the redirect as a `proto.LeaderHint` status detail instead. With a 0.8.0+ client against a 0.16.x server, the redirect is invisible to the client: retries keep targeting the client's cached (stale) shard leader and `node is not leader for shard N` errors persist until the client process restarts and re-fetches shard assignments. This was observed in production for ~6.5 hours after an Oxia pod replacement.

## Modifications

- Add a `LeaderHint` message to the client proto, mirroring the 0.16.x server definition (`shard`, `leader_address`).
- Parse the legacy `LeaderHint` gRPC status detail in `OxiaStatusException` and surface it through the existing `shard`/`leader` metadata, so `getLeaderHint()` works against 0.16.x servers and retries follow the server-provided leader.
- Add a unit test covering the legacy 0.16.x wire format (`type.googleapis.com/io.oxia.proto.v1.LeaderHint`).

## Testing

- `./gradlew :client:test --tests io.oxia.client.grpc.OxiaStatusExceptionTest --tests io.oxia.client.grpc.GrpcRpcProviderTest` passes.
- `:client:spotlessJavaCheck` passes for the changed files.
