### PR TITLE
fix: detect and recover from stale shard-assignments streams

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -260,6 +260,22 @@ public interface OxiaClientBuilder {
     OxiaClientBuilder connectionKeepAliveTime(Duration connectionKeepAlive);
 
     /**
+     * Configure the maximum time the client will wait for a shard-assignments update on the {@code
+     * GetShardAssignments} stream before it recreates the stream.
+     *
+     * <p>The servers push a full snapshot whenever the shard assignments change. If no update is
+     * received within this timeout the client assumes the stream is stale or half-open, cancels it
+     * and opens a fresh stream to re-fetch the assignments.
+     *
+     * <p>Default is <code>90 sec</code>. Size this to at least 3x the server's assignment push
+     * cadence.
+     *
+     * @param shardAssignmentsTimeout the shard assignments stream timeout
+     * @return the builder instance
+     */
+    OxiaClientBuilder shardAssignmentsTimeout(Duration shardAssignmentsTimeout);
+
+    /**
      * Configure the authentication plugin and its parameters.
      *
      * @param authPluginClassName the class name of the authentication plugin

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -85,7 +85,12 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         var rpcProvider =
                 RpcProvider.create(config, asyncExecutor, shardId -> shardManagerRef.get().leader(shardId));
         var shardManager =
-                new ShardManager(asyncExecutor, rpcProvider, instrumentProvider, config.namespace());
+                new ShardManager(
+                        asyncExecutor,
+                        rpcProvider,
+                        instrumentProvider,
+                        config.namespace(),
+                        config.shardAssignmentsTimeout());
         shardManagerRef.set(shardManager);
         var notificationManager =
                 new NotificationManager(asyncExecutor, rpcProvider, shardManager, instrumentProvider);

--- a/client/src/main/java/io/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/oxia/client/ClientConfig.java
@@ -40,4 +40,64 @@ public record ClientConfig(
         @NonNull Duration connectionBackoffMaxDelay,
         Duration connectionKeepAliveTime,
         Duration connectionKeepAliveTimeout,
-        int maxConnectionPerNode) {}
+        int maxConnectionPerNode,
+        @Nullable Duration shardAssignmentsTimeout) {
+
+    /**
+     * Default maximum time the client will wait for a shard-assignments update before recreating the
+     * {@code GetShardAssignments} stream. The servers push a full snapshot on every assignment
+     * change, so an interval of 3x the expected push cadence is a safe default.
+     */
+    public static final Duration DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT = Duration.ofSeconds(90);
+
+    public ClientConfig {
+        shardAssignmentsTimeout =
+                shardAssignmentsTimeout != null
+                        ? shardAssignmentsTimeout
+                        : DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT;
+    }
+
+    /** Backwards-compatible constructor for call sites that predate the shard-assignments timeout. */
+    public ClientConfig(
+            @NonNull String serviceAddress,
+            @NonNull Duration requestTimeout,
+            int maxRequestsPerBatch,
+            int maxBatchSize,
+            long maxPendingBytes,
+            int maxWriteBatchesInFlight,
+            int maxReadBatchesInFlight,
+            int batchingThreads,
+            @NonNull Duration sessionTimeout,
+            @NonNull String clientIdentifier,
+            OpenTelemetry openTelemetry,
+            @NonNull String namespace,
+            @Nullable Authentication authentication,
+            boolean enableTls,
+            @NonNull Duration connectionBackoffMinDelay,
+            @NonNull Duration connectionBackoffMaxDelay,
+            Duration connectionKeepAliveTime,
+            Duration connectionKeepAliveTimeout,
+            int maxConnectionPerNode) {
+        this(
+                serviceAddress,
+                requestTimeout,
+                maxRequestsPerBatch,
+                maxBatchSize,
+                maxPendingBytes,
+                maxWriteBatchesInFlight,
+                maxReadBatchesInFlight,
+                batchingThreads,
+                sessionTimeout,
+                clientIdentifier,
+                openTelemetry,
+                namespace,
+                authentication,
+                enableTls,
+                connectionBackoffMinDelay,
+                connectionBackoffMaxDelay,
+                connectionKeepAliveTime,
+                connectionKeepAliveTimeout,
+                maxConnectionPerNode,
+                DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
+    }
+}

--- a/client/src/main/java/io/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/oxia/client/ClientConfig.java
@@ -41,7 +41,7 @@ public record ClientConfig(
         Duration connectionKeepAliveTime,
         Duration connectionKeepAliveTimeout,
         int maxConnectionPerNode,
-        @Nullable Duration shardAssignmentsTimeout) {
+        @NonNull Duration shardAssignmentsTimeout) {
 
     /**
      * Default maximum time the client will wait for a shard-assignments update before recreating the
@@ -49,55 +49,4 @@ public record ClientConfig(
      * change, so an interval of 3x the expected push cadence is a safe default.
      */
     public static final Duration DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT = Duration.ofSeconds(90);
-
-    public ClientConfig {
-        shardAssignmentsTimeout =
-                shardAssignmentsTimeout != null
-                        ? shardAssignmentsTimeout
-                        : DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT;
-    }
-
-    /** Backwards-compatible constructor for call sites that predate the shard-assignments timeout. */
-    public ClientConfig(
-            @NonNull String serviceAddress,
-            @NonNull Duration requestTimeout,
-            int maxRequestsPerBatch,
-            int maxBatchSize,
-            long maxPendingBytes,
-            int maxWriteBatchesInFlight,
-            int maxReadBatchesInFlight,
-            int batchingThreads,
-            @NonNull Duration sessionTimeout,
-            @NonNull String clientIdentifier,
-            OpenTelemetry openTelemetry,
-            @NonNull String namespace,
-            @Nullable Authentication authentication,
-            boolean enableTls,
-            @NonNull Duration connectionBackoffMinDelay,
-            @NonNull Duration connectionBackoffMaxDelay,
-            Duration connectionKeepAliveTime,
-            Duration connectionKeepAliveTimeout,
-            int maxConnectionPerNode) {
-        this(
-                serviceAddress,
-                requestTimeout,
-                maxRequestsPerBatch,
-                maxBatchSize,
-                maxPendingBytes,
-                maxWriteBatchesInFlight,
-                maxReadBatchesInFlight,
-                batchingThreads,
-                sessionTimeout,
-                clientIdentifier,
-                openTelemetry,
-                namespace,
-                authentication,
-                enableTls,
-                connectionBackoffMinDelay,
-                connectionBackoffMaxDelay,
-                connectionKeepAliveTime,
-                connectionKeepAliveTimeout,
-                maxConnectionPerNode,
-                DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
-    }
 }

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -57,6 +57,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public static final int DefaultBatchingThreads = 1;
     public static final Duration DefaultRequestTimeout = Duration.ofSeconds(30);
     public static final Duration DefaultSessionTimeout = Duration.ofSeconds(15);
+    public static final Duration DefaultShardAssignmentsTimeout = Duration.ofSeconds(90);
     public static final String DefaultNamespace = "default";
     public static final boolean DefaultEnableTls = false;
     public static final int DefaultMaxConnectionPerNode = 1;
@@ -91,6 +92,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
     protected Duration connectionKeepAliveTime = Duration.ofSeconds(10);
     protected Duration connectionKeepAliveTimeout = Duration.ofSeconds(3);
+    @NonNull protected Duration shardAssignmentsTimeout = DefaultShardAssignmentsTimeout;
 
     protected int maxConnectionsPerNode = DefaultMaxConnectionPerNode;
 
@@ -253,6 +255,16 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     }
 
     @Override
+    public OxiaClientBuilder shardAssignmentsTimeout(@NonNull Duration shardAssignmentsTimeout) {
+        if (shardAssignmentsTimeout.isNegative() || shardAssignmentsTimeout.equals(ZERO)) {
+            throw new IllegalArgumentException(
+                    "shardAssignmentsTimeout must be greater than zero: " + shardAssignmentsTimeout);
+        }
+        this.shardAssignmentsTimeout = shardAssignmentsTimeout;
+        return this;
+    }
+
+    @Override
     public OxiaClientBuilder authentication(String authPluginClassName, String authParamsString)
             throws UnsupportedAuthenticationException {
         this.authPluginClassName = authPluginClassName;
@@ -392,7 +404,8 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                 connectionBackoffMaxDelay,
                 connectionKeepAliveTime,
                 connectionKeepAliveTimeout,
-                maxConnectionsPerNode);
+                maxConnectionsPerNode,
+                shardAssignmentsTimeout);
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -133,7 +133,12 @@ public class SharedResourcesImpl implements SharedResources {
                 RpcProvider.create(
                         config, executor, connectionManager, shardId -> shardManagerRef.get().leader(shardId));
         var shardManager =
-                new ShardManager(executor, rpcProvider, instrumentProvider, config.namespace());
+                new ShardManager(
+                        executor,
+                        rpcProvider,
+                        instrumentProvider,
+                        config.namespace(),
+                        config.shardAssignmentsTimeout());
         shardManagerRef.set(shardManager);
         return new SharedNamespace(rpcProvider, shardManager, shardManager.start());
     }

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -278,7 +278,8 @@ public class SharedResourcesImpl implements SharedResources {
                             connectionBackoffMaxDelay,
                             connectionKeepAliveTime,
                             connectionKeepAliveTimeout,
-                            maxConnectionPerNode);
+                            maxConnectionPerNode,
+                            ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
             return new SharedResourcesImpl(numWorkerThreads, transportConfig);
         }
     }

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -68,6 +68,8 @@ final class GrpcRpcProvider implements RpcProvider {
     private final ScheduledExecutorService asyncExecutor;
     private final LongFunction<String> shardLeaderProvider;
     private final Map<Long, ManagedWriteStream> writeStreams;
+    private final AtomicReference<CancelableStreamObserver<ShardAssignments>> shardAssignmentsStream =
+            new AtomicReference<>();
 
     GrpcRpcProvider(
             @NonNull ClientConfig clientConfig,
@@ -113,9 +115,40 @@ final class GrpcRpcProvider implements RpcProvider {
                     .with(asyncExecutor)
                     .getStageAsync(
                             () -> {
-                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierFuture =
+                                        new CompletableFuture<Void>()
+                                                .orTimeout(
+                                                        clientConfig.shardAssignmentsTimeout().toMillis(),
+                                                        TimeUnit.MILLISECONDS);
+                                final var cancelable =
+                                        new CancelableStreamObserver<ShardAssignments>() {
+                                            @Override
+                                            protected void handleNext(ShardAssignments value) {
+                                                guardedObserver.onNext(value);
+                                            }
+
+                                            @Override
+                                            protected void handleError(Throwable t) {
+                                                guardedObserver.onError(t);
+                                            }
+
+                                            @Override
+                                            protected void handleComplete() {
+                                                guardedObserver.onCompleted();
+                                            }
+                                        };
                                 final var barrierObserver =
-                                        ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
+                                        ManagedObservers.toBarrierClientResponseObserver(cancelable, barrierFuture);
+                                // If the attempt times out or fails before delivering the first
+                                // snapshot, cancel the underlying call so it does not linger as a
+                                // half-open stream.
+                                barrierFuture.whenComplete(
+                                        (unused, error) -> {
+                                            if (error != null) {
+                                                cancelable.cancel();
+                                            }
+                                        });
+                                shardAssignmentsStream.set(cancelable);
                                 try {
                                     connectionManager
                                             .getConnection(clientConfig.serviceAddress())
@@ -133,6 +166,14 @@ final class GrpcRpcProvider implements RpcProvider {
                             });
         } catch (Throwable error) {
             guardedObserver.onError(OxiaStatusException.from(error));
+        }
+    }
+
+    @Override
+    public void cancelShardAssignments() {
+        final var stream = shardAssignmentsStream.get();
+        if (stream != null) {
+            stream.cancel();
         }
     }
 

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -117,9 +117,7 @@ final class GrpcRpcProvider implements RpcProvider {
                             () -> {
                                 final var barrierFuture =
                                         new CompletableFuture<Void>()
-                                                .orTimeout(
-                                                        clientConfig.shardAssignmentsTimeout().toMillis(),
-                                                        TimeUnit.MILLISECONDS);
+                                                .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var cancelable =
                                         new CancelableStreamObserver<ShardAssignments>() {
                                             @Override

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -50,6 +50,15 @@ public interface RpcProvider extends AutoCloseable {
     void getShardAssignments(
             @NonNull ShardAssignmentsRequest request, @NonNull StreamObserver<ShardAssignments> observer);
 
+    /**
+     * Cancel the currently active shard-assignments stream, if any.
+     *
+     * <p>Invoked by the {@code ShardManager} when it detects that the stream has become stale (no
+     * assignments update received for a configurable period). Cancelling the underlying call forces
+     * the stream to terminate so a fresh stream can be created.
+     */
+    default void cancelShardAssignments() {}
+
     void getNotifications(
             @NonNull NotificationsRequest request, @NonNull StreamObserver<NotificationBatch> observer);
 

--- a/client/src/main/java/io/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardManager.java
@@ -38,12 +38,14 @@ import io.oxia.client.util.Backoff;
 import io.oxia.proto.NamespaceShardsAssignment;
 import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -60,6 +62,14 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
     private final Backoff backoff = new Backoff();
     private final CompletableFuture<Void> initialAssignmentsFuture;
 
+    private static final Duration DEFAULT_WATCHDOG_INTERVAL = Duration.ofSeconds(90);
+
+    private final long watchdogIntervalNanos;
+    private ScheduledFuture<?> watchdogTask;
+    private boolean watchdogStarted;
+
+    private volatile long lastUpdateNanos;
+
     private volatile boolean closed;
 
     private final Counter shardAssignmentsEvents;
@@ -69,11 +79,22 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
             @NonNull RpcProvider rpcProvider,
             @NonNull InstrumentProvider instrumentProvider,
             @NonNull String namespace) {
+        this(asyncExecutor, rpcProvider, instrumentProvider, namespace, DEFAULT_WATCHDOG_INTERVAL);
+    }
+
+    public ShardManager(
+            @NonNull ScheduledExecutorService asyncExecutor,
+            @NonNull RpcProvider rpcProvider,
+            @NonNull InstrumentProvider instrumentProvider,
+            @NonNull String namespace,
+            @NonNull Duration watchdogInterval) {
         this.rpcProvider = rpcProvider;
         this.asyncExecutor = asyncExecutor;
         this.assignments = new ShardAssignmentsContainer(Xxh332HashRangeShardStrategy, namespace);
         this.callbacks = new CompositeConsumer<>();
         this.initialAssignmentsFuture = new CompletableFuture<>();
+        this.watchdogIntervalNanos = watchdogInterval.toNanos();
+        this.lastUpdateNanos = System.nanoTime();
         this.log =
                 Logger.get(ShardManager.class).with().attr("namespace", assignments.getNamespace()).build();
 
@@ -88,6 +109,11 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
     @Override
     public void close() {
         closed = true;
+        synchronized (this) {
+            if (watchdogTask != null) {
+                watchdogTask.cancel(false);
+            }
+        }
     }
 
     public CompletableFuture<Void> start() {
@@ -95,11 +121,13 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
         req.setNamespace(assignments.getNamespace());
 
         rpcProvider.getShardAssignments(req, this);
+        startWatchdog();
         return initialAssignmentsFuture;
     }
 
     @Override
     public void onNext(ShardAssignments assignments) {
+        lastUpdateNanos = System.nanoTime();
         shardAssignmentsEvents.increment();
         updateAssignments(assignments);
         backoff.reset();
@@ -114,6 +142,7 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
             return;
         }
 
+        lastUpdateNanos = System.nanoTime();
         final var oxiaError = OxiaStatusException.from(error);
         if (oxiaError.getStatusCode() == NAMESPACE_NOT_FOUND && !initialAssignmentsFuture.isDone()) {
             log.error("Namespace not found");
@@ -141,6 +170,7 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
             return;
         }
 
+        lastUpdateNanos = System.nanoTime();
         log.warn("Stream closed while receiving shard assignments");
         asyncExecutor.schedule(
                 () -> {
@@ -175,6 +205,45 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
         var changes = computeShardLeaderChanges(assignments.allShards(), updatedMap);
         assignments.update(changes);
         callbacks.accept(changes);
+    }
+
+    private void checkForStaleStream() {
+        if (closed) {
+            return;
+        }
+
+        final long lastUpdate = lastUpdateNanos;
+        if (System.nanoTime() - lastUpdate < watchdogIntervalNanos) {
+            return;
+        }
+
+        // No shard-assignments update for longer than the watchdog interval. The stream is either
+        // half-open (its server-side handler died without delivering a terminal event) or silently
+        // stalled. Cancel it and open a fresh stream to re-fetch the assignments.
+        lastUpdateNanos = System.nanoTime();
+        log.warn(
+                "No shard assignments received for "
+                        + watchdogIntervalNanos / 1_000_000
+                        + " ms, recreating the stream");
+        try {
+            rpcProvider.cancelShardAssignments();
+        } catch (Throwable t) {
+            log.warn().exceptionMessage(t).log("Failed to cancel the shard assignments stream");
+        }
+        start();
+    }
+
+    private synchronized void startWatchdog() {
+        if (closed || watchdogStarted) {
+            return;
+        }
+        watchdogStarted = true;
+        watchdogTask =
+                asyncExecutor.scheduleWithFixedDelay(
+                        this::checkForStaleStream,
+                        watchdogIntervalNanos / 2,
+                        watchdogIntervalNanos / 2,
+                        TimeUnit.NANOSECONDS);
     }
 
     @VisibleForTesting

--- a/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
@@ -63,7 +63,8 @@ class BatchManagerTest {
                     Duration.ofSeconds(30),
                     Duration.ofSeconds(10),
                     Duration.ofSeconds(5),
-                    1);
+                    1,
+                    ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
 
     BatcherPool pool;
     BatchManager manager;

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -118,7 +118,8 @@ class BatchTest {
                     Duration.ofSeconds(30),
                     Duration.ofSeconds(10),
                     Duration.ofSeconds(5),
-                    1);
+                    1,
+                    ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
 
     private final OxiaClientImplBase serviceImpl =
             mock(
@@ -460,7 +461,8 @@ class BatchTest {
                             Duration.ofSeconds(30),
                             Duration.ofSeconds(10),
                             Duration.ofSeconds(5),
-                            1);
+                            1,
+                            ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
             return new WriteBatchFactory(
                     mock(RpcProvider.class),
                     mock(SessionManager.class),
@@ -663,7 +665,8 @@ class BatchTest {
                             Duration.ofSeconds(30),
                             Duration.ofSeconds(10),
                             Duration.ofSeconds(5),
-                            1);
+                            1,
+                            ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
             return new ReadBatchFactory(mock(RpcProvider.class), windowConfig, InstrumentProvider.NOOP);
         }
 
@@ -760,7 +763,8 @@ class BatchTest {
                         Duration.ofSeconds(30),
                         Duration.ofSeconds(10),
                         Duration.ofSeconds(5),
-                        1);
+                        1,
+                        ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
 
         @Nested
         @DisplayName("Tests of write batch factory")

--- a/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
@@ -64,7 +64,8 @@ class BatcherPoolTest {
                     Duration.ofSeconds(30),
                     Duration.ofSeconds(10),
                     Duration.ofSeconds(5),
-                    1);
+                    1,
+                    ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
 
     BatcherPool pool;
 

--- a/client/src/test/java/io/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherTest.java
@@ -65,7 +65,8 @@ class BatcherTest {
                     Duration.ofSeconds(30),
                     Duration.ofSeconds(10),
                     Duration.ofSeconds(5),
-                    1);
+                    1,
+                    ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
 
     Batcher batcher;
 

--- a/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
@@ -77,7 +77,8 @@ class SessionManagerTest {
                         Duration.ofMillis(100),
                         Duration.ofSeconds(10),
                         Duration.ofSeconds(3),
-                        1);
+                        1,
+                        ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
         manager = new SessionManager(executor, config, rpcProvider, InstrumentProvider.NOOP);
     }
 

--- a/client/src/test/java/io/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionTest.java
@@ -85,7 +85,8 @@ class SessionTest {
                         Duration.ofSeconds(30),
                         Duration.ofSeconds(10),
                         Duration.ofSeconds(5),
-                        1);
+                        1,
+                        ClientConfig.DEFAULT_SHARD_ASSIGNMENTS_TIMEOUT);
 
         String serverName = InProcessServerBuilder.generateName();
         service = new TestService();

--- a/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
+++ b/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
@@ -19,6 +19,7 @@ import static io.oxia.client.OxiaClientBuilderImpl.DefaultNamespace;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -205,6 +207,113 @@ public class ShardManagerTest {
         }
 
         @Test
+        void recreatesStreamWhenNoAssignmentsReceivedForWatchdogInterval() {
+            manager =
+                    new ShardManager(
+                            asyncExecutor,
+                            rpcProvider,
+                            InstrumentProvider.NOOP,
+                            DefaultNamespace,
+                            Duration.ofMillis(200));
+
+            var leader0 = assignment(0, "leader0");
+            var leader1 = assignment(0, "leader1");
+            var stubCalls = new AtomicInteger();
+
+            doAnswer(
+                            invocation -> {
+                                if (stubCalls.getAndIncrement() == 0) {
+                                    // The first stream delivers one snapshot and then goes silent:
+                                    // this reproduces the zombie-stream scenario where the server
+                                    // half of the stream is gone but the client never receives a
+                                    // terminal event.
+                                    manager.onNext(assignments(leader0));
+                                } else {
+                                    // The recreated stream delivers the current snapshot.
+                                    manager.onNext(assignments(leader1));
+                                }
+                                return null;
+                            })
+                    .when(rpcProvider)
+                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+
+            assertThat(manager.start()).succeedsWithin(Duration.ofSeconds(1));
+            assertThat(manager.leader(0)).isEqualTo("leader0");
+
+            // Without the watchdog the stale assignment would be kept forever.
+            await()
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(manager.leader(0)).isEqualTo("leader1"));
+            assertThat(stubCalls.get()).isGreaterThanOrEqualTo(2);
+            verify(rpcProvider).cancelShardAssignments();
+        }
+
+        @Test
+        void recreatesStreamWhenFirstSnapshotNeverArrives() {
+            manager =
+                    new ShardManager(
+                            asyncExecutor,
+                            rpcProvider,
+                            InstrumentProvider.NOOP,
+                            DefaultNamespace,
+                            Duration.ofMillis(200));
+
+            var assignment = assignment(0, "leader0");
+            var stubCalls = new AtomicInteger();
+
+            doAnswer(
+                            invocation -> {
+                                // The first attempt never delivers anything (half-open stream).
+                                if (stubCalls.getAndIncrement() > 0) {
+                                    manager.onNext(assignments(assignment));
+                                }
+                                return null;
+                            })
+                    .when(rpcProvider)
+                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+
+            manager.start();
+
+            await()
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(manager.allShardIds()).contains(0L));
+            assertThat(stubCalls.get()).isGreaterThanOrEqualTo(2);
+            verify(rpcProvider).cancelShardAssignments();
+        }
+
+        @Test
+        void doesNotRecreateStreamWhileReceivingUpdates() throws Exception {
+            manager =
+                    new ShardManager(
+                            asyncExecutor,
+                            rpcProvider,
+                            InstrumentProvider.NOOP,
+                            DefaultNamespace,
+                            Duration.ofMillis(500));
+
+            var assignment = assignment(0, "leader0");
+            var stubCalls = new AtomicInteger();
+
+            doAnswer(
+                            invocation -> {
+                                stubCalls.incrementAndGet();
+                                // Keep the stream healthy by delivering updates more often than the
+                                // watchdog interval.
+                                asyncExecutor.scheduleWithFixedDelay(
+                                        () -> manager.onNext(assignments(assignment)), 100, 100, TimeUnit.MILLISECONDS);
+                                return null;
+                            })
+                    .when(rpcProvider)
+                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+
+            manager.start();
+
+            Thread.sleep(1200);
+            assertThat(stubCalls.get()).isEqualTo(1);
+            assertThat(manager.leader(0)).isEqualTo("leader0");
+        }
+
+        @Test
         void get() {
             assertThatThrownBy(() -> manager.getShardForKey("a"))
                     .isInstanceOf(OxiaStatusException.class)
@@ -231,6 +340,19 @@ public class ShardManagerTest {
                                 assertThat(oxiaError.getStatusCode()).isEqualTo(OxiaStatusCode.SHARD_NOT_FOUND);
                                 assertThat(oxiaError.getMetadata()).containsEntry("shard", "1");
                             });
+        }
+
+        private ShardAssignments assignments(ShardAssignment assignment) {
+            var sa = new ShardAssignments();
+            sa.putNamespaces(namespace).addAssignment().copyFrom(assignment);
+            return sa;
+        }
+
+        private ShardAssignment assignment(long shardId, String leader) {
+            var assignment = new ShardAssignment();
+            assignment.setShard(shardId).setLeader(leader);
+            assignment.setInt32HashRange().setMinHashInclusive(0).setMaxHashInclusive(Integer.MAX_VALUE);
+            return assignment;
         }
 
         @Test


### PR DESCRIPTION
## Motivation

The `GetShardAssignments` server-streaming RPC can become "half-open": its server-side handler ends (for example when the serving Oxia pod is replaced) without the client ever receiving a terminal event. gRPC channel-level health checks and keepalive only validate the transport, which stays healthy, so the client keeps the last assignment snapshot forever and routes data and notifications to stale leaders — producing constant `node is not leader` errors for hours (reproduced in a staging cluster: one forced Oxia pod kill caused a continuous error stream until the client was restarted or its stream was manually recreated).

Additionally, each retry attempt is bounded by a `BarrierStreamObserver` future that completes on the first snapshot. A half-open attempt that never delivers and never errors leaves that future pending forever, leaking the underlying call and stalling all further retries (verified live: a permanently incomplete barrier future owned by the shard manager).

## Modifications

- `ShardManager`: add a stream watchdog that tracks the last received assignment update and recreates the `GetShardAssignments` stream when no update arrives within a configurable interval (default 90s, sized at ~3x the server push cadence). `onError`/`onCompleted` reset the watchdog so the existing backoff retry path is not disturbed.
- `GrpcRpcProvider`: bound each stream attempt with `CompletableFuture.orTimeout` using the existing `requestTimeout`, and cancel the underlying call when the attempt times out or fails before delivering the first snapshot, so half-open streams cannot linger or leak.
- `RpcProvider`: add a default `cancelShardAssignments()` hook that `ShardManager` invokes before recreating the stream.
- `ClientConfig`/`OxiaClientBuilder`: add the `shardAssignmentsTimeout` option (default 90s) controlling the stream watchdog, updating the `ClientConfig` construction sites to pass the value explicitly.

## Testing

- New unit tests in `ShardManagerTest` that reproduce the incident scenarios and verify recovery:
  - stream delivers a snapshot then goes silent → watchdog recreates the stream and the updated snapshot is applied (fails without the fix: leader stays stale forever);
  - stream never delivers a first snapshot (half-open) → watchdog recreates the stream and assignments arrive (fails without the fix);
  - healthy stream receiving updates is not recreated (no churn).
- `./gradlew :client:test` passes for all unit tests; the only failures in the full suite are the pre-existing Testcontainers integration tests that require Docker (unavailable in this environment).
- `spotlessCheck` passes.
