### PR TITLE
fix: bound stream establishment with requestTimeout so hung attempts fail fast

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -113,7 +113,9 @@ final class GrpcRpcProvider implements RpcProvider {
                     .with(asyncExecutor)
                     .getStageAsync(
                             () -> {
-                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierFuture =
+                                        new CompletableFuture<Void>()
+                                                .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
                                 try {
@@ -146,7 +148,9 @@ final class GrpcRpcProvider implements RpcProvider {
                     .with(asyncExecutor)
                     .getStageAsync(
                             () -> {
-                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierFuture =
+                                        new CompletableFuture<Void>()
+                                                .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
                                 try {
@@ -246,7 +250,9 @@ final class GrpcRpcProvider implements RpcProvider {
                     .with(asyncExecutor)
                     .getStageAsync(
                             () -> {
-                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierFuture =
+                                        new CompletableFuture<Void>()
+                                                .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
                                 try {
@@ -314,7 +320,9 @@ final class GrpcRpcProvider implements RpcProvider {
                     .with(asyncExecutor)
                     .getStageAsync(
                             () -> {
-                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierFuture =
+                                        new CompletableFuture<Void>()
+                                                .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
                                 try {
@@ -347,7 +355,9 @@ final class GrpcRpcProvider implements RpcProvider {
                     .with(asyncExecutor)
                     .getStageAsync(
                             () -> {
-                                final var barrierFuture = new CompletableFuture<Void>();
+                                final var barrierFuture =
+                                        new CompletableFuture<Void>()
+                                                .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
                                 try {

--- a/client/src/main/java/io/oxia/client/grpc/observer/GuardedStreamObserver.java
+++ b/client/src/main/java/io/oxia/client/grpc/observer/GuardedStreamObserver.java
@@ -30,7 +30,9 @@ public final class GuardedStreamObserver<T> implements StreamObserver<T> {
 
     @Override
     public void onNext(@NonNull T response) {
-        streamObserver.onNext(response);
+        if (!terminated.get()) {
+            streamObserver.onNext(response);
+        }
     }
 
     @Override

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -48,8 +48,12 @@ import io.oxia.proto.RangeScanResponse;
 import io.oxia.proto.ReadRequest;
 import io.oxia.proto.ReadResponse;
 import io.oxia.proto.SessionHeartbeat;
+import io.oxia.proto.ShardAssignments;
+import io.oxia.proto.ShardAssignmentsRequest;
 import io.oxia.proto.WriteResponse;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -716,6 +720,563 @@ class GrpcRpcProviderTest {
                             });
         } finally {
             executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void getShardAssignmentsTimesOutSilentAttempt() throws Exception {
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getShardAssignments(
+                                            ShardAssignmentsRequest request,
+                                            StreamObserver<ShardAssignments> responseObserver) {
+                                        try {
+                                            // Keep the stream open without ever delivering a message
+                                            new CountDownLatch(1).await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.getShardAssignments(
+                    new ShardAssignmentsRequest(),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ShardAssignments value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            error.set(t);
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(error.get()).isInstanceOf(OxiaStatusException.class);
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void getShardAssignmentsLateMessagesAfterTimeoutAreIgnored() throws Exception {
+        var sendLateMessage = new CountDownLatch(1);
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getShardAssignments(
+                                            ShardAssignmentsRequest request,
+                                            StreamObserver<ShardAssignments> responseObserver) {
+                                        try {
+                                            // Stay silent longer than the request timeout, then deliver
+                                            // a snapshot after the client already timed out.
+                                            sendLateMessage.await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                        responseObserver.onNext(new ShardAssignments());
+                                        responseObserver.onCompleted();
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+        var received = new AtomicInteger();
+        var terminalEvents = new AtomicInteger();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.getShardAssignments(
+                    new ShardAssignmentsRequest(),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ShardAssignments value) {
+                            received.incrementAndGet();
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            error.set(t);
+                            terminalEvents.incrementAndGet();
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminalEvents.incrementAndGet();
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+
+            sendLateMessage.countDown();
+            Thread.sleep(1000);
+            assertThat(received.get()).isZero();
+            assertThat(terminalEvents.get()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void getShardAssignmentsIsNotTimedOutAfterFirstMessage() throws Exception {
+        var releaseStream = new CountDownLatch(1);
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getShardAssignments(
+                                            ShardAssignmentsRequest request,
+                                            StreamObserver<ShardAssignments> responseObserver) {
+                                        responseObserver.onNext(new ShardAssignments());
+                                        try {
+                                            // Stay silent longer than the request timeout
+                                            releaseStream.await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                        responseObserver.onNext(new ShardAssignments());
+                                        responseObserver.onCompleted();
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var received = new AtomicInteger();
+        var secondMessage = new CountDownLatch(1);
+        var error = new AtomicReference<Throwable>();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.getShardAssignments(
+                    new ShardAssignmentsRequest(),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ShardAssignments value) {
+                            if (received.incrementAndGet() == 2) {
+                                secondMessage.countDown();
+                            }
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            error.set(t);
+                        }
+
+                        @Override
+                        public void onCompleted() {}
+                    });
+
+            await().untilAsserted(() -> assertThat(received.get()).isEqualTo(1));
+            Thread.sleep(1200);
+            assertThat(error.get()).isNull();
+            assertThat(received.get()).isEqualTo(1);
+
+            releaseStream.countDown();
+            assertThat(secondMessage.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(error.get()).isNull();
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void getNotificationsTimesOutSilentInitialAttempt() throws Exception {
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getNotifications(
+                                            NotificationsRequest request,
+                                            StreamObserver<NotificationBatch> responseObserver) {
+                                        try {
+                                            new CountDownLatch(1).await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            var request = new NotificationsRequest();
+            request.setShard(1);
+            provider.getNotifications(
+                    request,
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(NotificationBatch value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            error.set(t);
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(error.get()).isInstanceOf(OxiaStatusException.class);
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void getNotificationsReconnectWithOffsetTimesOutSilentAttempt() throws Exception {
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getNotifications(
+                                            NotificationsRequest request,
+                                            StreamObserver<NotificationBatch> responseObserver) {
+                                        try {
+                                            new CountDownLatch(1).await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            var request = new NotificationsRequest();
+            request.setShard(1);
+            request.setStartOffsetExclusive(5);
+            provider.getNotifications(
+                    request,
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(NotificationBatch value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            error.set(t);
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(error.get()).isInstanceOf(OxiaStatusException.class);
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void readTimesOutSilentAttempt() throws Exception {
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void read(
+                                            ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+                                        try {
+                                            new CountDownLatch(1).await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.read(
+                    new ReadRequest(),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ReadResponse value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            error.set(t);
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(error.get()).isInstanceOf(OxiaStatusException.class);
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void listTimesOutSilentAttempt() throws Exception {
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void list(
+                                            ListRequest request, StreamObserver<ListResponse> responseObserver) {
+                                        try {
+                                            new CountDownLatch(1).await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.list(
+                    new ListRequest(),
+                    new CancelableStreamObserver<>() {
+                        @Override
+                        protected void handleNext(ListResponse value) {}
+
+                        @Override
+                        protected void handleError(Throwable t) {
+                            error.set(t);
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        protected void handleComplete() {
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(error.get()).isInstanceOf(OxiaStatusException.class);
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void listLateMessagesAfterTimeoutAreIgnored() throws Exception {
+        var sendLateMessage = new CountDownLatch(1);
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void list(
+                                            ListRequest request, StreamObserver<ListResponse> responseObserver) {
+                                        try {
+                                            // Stay silent longer than the request timeout, then deliver
+                                            // a message after the client already timed out.
+                                            sendLateMessage.await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                        responseObserver.onNext(new ListResponse().addAllKeys(List.of("key")));
+                                        responseObserver.onCompleted();
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+        var received = new AtomicInteger();
+        var terminalEvents = new AtomicInteger();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.list(
+                    new ListRequest(),
+                    new CancelableStreamObserver<>() {
+                        @Override
+                        protected void handleNext(ListResponse value) {
+                            received.incrementAndGet();
+                        }
+
+                        @Override
+                        protected void handleError(Throwable t) {
+                            error.set(t);
+                            terminalEvents.incrementAndGet();
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        protected void handleComplete() {
+                            terminalEvents.incrementAndGet();
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+
+            sendLateMessage.countDown();
+            Thread.sleep(1000);
+            assertThat(received.get()).isZero();
+            assertThat(terminalEvents.get()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void rangeScanTimesOutSilentAttempt() throws Exception {
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void rangeScan(
+                                            RangeScanRequest request,
+                                            StreamObserver<RangeScanResponse> responseObserver) {
+                                        try {
+                                            new CountDownLatch(1).await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address).requestTimeout(Duration.ofMillis(500)))
+                        .getClientConfig();
+        var error = new AtomicReference<Throwable>();
+        var terminated = new CountDownLatch(1);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.rangeScan(
+                    new RangeScanRequest(),
+                    new CancelableStreamObserver<>() {
+                        @Override
+                        protected void handleNext(RangeScanResponse value) {}
+
+                        @Override
+                        protected void handleError(Throwable t) {
+                            error.set(t);
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        protected void handleComplete() {
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(error.get()).isInstanceOf(OxiaStatusException.class);
+            assertThat(((OxiaStatusException) error.get()).getStatusCode())
+                    .isEqualTo(OxiaStatusCode.TIMEOUT);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
         }
     }
 


### PR DESCRIPTION
## Motivation

The `GetShardAssignments`, `GetNotifications`, `Read`, `List` and `RangeScan` server-streaming RPCs establish their stream through a barrier future that completes on the first message (or terminal event). The barrier had no deadline, so a silent or half-open attempt — for example a server-side handler that ended without sending a terminal event, such as after an Oxia pod replacement behind an L7 proxy that answers transport keepalives locally — left the future pending forever, stalling retries and leaking calls.

## Modifications

- Bound the establishment of all five server-streaming calls with `requestTimeout` via `CompletableFuture.orTimeout` on the barrier, so a silent attempt fails fast with `TIMEOUT` and the existing retry/error paths recover.
- Harden `GuardedStreamObserver` to drop `onNext` after a terminal event. The barrier observers forward messages unconditionally, so without this a timed-out attempt that later delivers data would feed stale snapshots/responses into the retried stream.
- `list` and `rangeScan` deliver the error on the caller-owned `CancelableStreamObserver`; its own termination already drops late messages.
- Notifications are subject to the timeout on every subscription, including reconnects that resume from an explicit start offset; reconnects resume from the last received offset, so the reconnect churn is lossless.
- `getSequenceUpdates` is intentionally unchanged: its server-side stream can be silent indefinitely for a key with no existing sequence, so an establishment timeout would churn idle subscriptions.

The timed-out call itself is not actively cancelled in this PR; the timeout is the containment, and the observer-side suppression keeps late data from reaching the caller. Cancelling the underlying call on timeout is planned as a follow-up.

## Testing

- New `GrpcRpcProviderTest` unit tests with in-process gRPC servers:
  - a silent attempt for each changed RPC times out with `TIMEOUT`, including a notifications reconnect that resumes from an offset;
  - a healthy shard-assignments stream that goes silent after its first message is not torn down by the timeout;
  - late messages delivered after a timeout are ignored and do not produce a second terminal event, for both the guarded-observer path (`getShardAssignments`) and the caller-owned path (`list`).
- `./gradlew :client:test` passes for all unit tests; the only failures in the full suite are the pre-existing Testcontainers integration tests that require Docker (unavailable in this environment).
- `./gradlew spotlessCheck` passes.