### PR TITLE
feat: refresh long-lived streams when idle

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -82,6 +82,18 @@ public interface OxiaClientBuilder {
     OxiaClientBuilder requestTimeout(Duration requestTimeout);
 
     /**
+     * Specify how long a long-lived stream (shard assignments, notifications, sequence updates) may
+     * be idle before the client cancels it and opens a fresh stream to recover from silent or
+     * half-open connections.
+     *
+     * <p>Default is <code>90 secs</code>.
+     *
+     * @param idleTimeout the maximum idle time
+     * @return the builder instance
+     */
+    OxiaClientBuilder idleTimeout(Duration idleTimeout);
+
+    /**
      * Specify the maximum time to wait for a batch to be sent.
      *
      * @param batchLinger the batch linger duration

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -85,10 +85,16 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         var rpcProvider =
                 RpcProvider.create(config, asyncExecutor, shardId -> shardManagerRef.get().leader(shardId));
         var shardManager =
-                new ShardManager(asyncExecutor, rpcProvider, instrumentProvider, config.namespace());
+                new ShardManager(
+                        asyncExecutor,
+                        rpcProvider,
+                        instrumentProvider,
+                        config.namespace(),
+                        config.idleTimeout());
         shardManagerRef.set(shardManager);
         var notificationManager =
-                new NotificationManager(asyncExecutor, rpcProvider, shardManager, instrumentProvider);
+                new NotificationManager(
+                        asyncExecutor, rpcProvider, shardManager, instrumentProvider, config.idleTimeout());
         shardManager.addCallback(notificationManager);
         var readBatcherPool = new BatcherPool("oxia-read-batcher", config.batchingThreads());
         var readBatchManager =
@@ -113,6 +119,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                         writeBatchManager,
                         sessionManager,
                         config.requestTimeout(),
+                        config.idleTimeout(),
                         config.maxPendingBytes(),
                         true);
         return shardManager.start().thenApply(v -> client);
@@ -138,7 +145,11 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                                             config, asyncExecutor, connectionManager, shardManager::leader);
                             var notificationManager =
                                     new NotificationManager(
-                                            asyncExecutor, rpcProvider, shardManager, instrumentProvider);
+                                            asyncExecutor,
+                                            rpcProvider,
+                                            shardManager,
+                                            instrumentProvider,
+                                            config.idleTimeout());
                             shardManager.addCallback(notificationManager);
                             var readBatchManager =
                                     BatchManager.newReadBatchManager(
@@ -169,6 +180,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                                     writeBatchManager,
                                     sessionManager,
                                     config.requestTimeout(),
+                                    config.idleTimeout(),
                                     config.maxPendingBytes(),
                                     false);
                         });
@@ -183,6 +195,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
     private final @NonNull BatchManager writeBatchManager;
     private final @NonNull SessionManager sessionManager;
     private final long requestTimeoutMs;
+    private final @NonNull Duration idleTimeout;
     private final @NonNull PendingBytesLimiter pendingBytesLimiter;
     private volatile boolean closed;
 
@@ -227,6 +240,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
             @NonNull BatchManager writeBatchManager,
             @NonNull SessionManager sessionManager,
             Duration requestTimeout,
+            @NonNull Duration idleTimeout,
             long maxPendingBytes,
             boolean ownsResources) {
         this.clientIdentifier = clientIdentifier;
@@ -241,6 +255,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
         this.scheduledExecutor = scheduledExecutor;
         this.ownsResources = ownsResources;
         this.requestTimeoutMs = requestTimeout.toMillis();
+        this.idleTimeout = idleTimeout;
 
         counterPutBytes =
                 instrumentProvider.newCounter(
@@ -795,7 +810,9 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 this.rpcProvider,
                 this.shardManager,
                 this.instrumentProvider,
-                x -> closed);
+                x -> closed,
+                this.scheduledExecutor,
+                this.idleTimeout);
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/oxia/client/ClientConfig.java
@@ -24,6 +24,7 @@ import lombok.NonNull;
 public record ClientConfig(
         @NonNull String serviceAddress,
         @NonNull Duration requestTimeout,
+        @NonNull Duration idleTimeout,
         int maxRequestsPerBatch,
         int maxBatchSize,
         long maxPendingBytes,

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -56,6 +56,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public static final int DefaultMaxReadBatchesInFlight = 4;
     public static final int DefaultBatchingThreads = 1;
     public static final Duration DefaultRequestTimeout = Duration.ofSeconds(30);
+    public static final Duration DefaultIdleTimeout = Duration.ofSeconds(90);
     public static final Duration DefaultSessionTimeout = Duration.ofSeconds(15);
     public static final String DefaultNamespace = "default";
     public static final boolean DefaultEnableTls = false;
@@ -63,6 +64,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
     @NonNull protected final String serviceAddress;
     @NonNull protected Duration requestTimeout = DefaultRequestTimeout;
+    @NonNull protected Duration idleTimeout = DefaultIdleTimeout;
 
     // Unused, but kept so that loadConfig() keeps accepting the "batchLinger" property
     @Deprecated(since = "0.9.0", forRemoval = true)
@@ -110,6 +112,15 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                     "requestTimeout must be greater than zero: " + requestTimeout);
         }
         this.requestTimeout = requestTimeout;
+        return this;
+    }
+
+    @Override
+    public @NonNull OxiaClientBuilder idleTimeout(@NonNull Duration idleTimeout) {
+        if (idleTimeout.isNegative() || idleTimeout.equals(ZERO)) {
+            throw new IllegalArgumentException("idleTimeout must be greater than zero: " + idleTimeout);
+        }
+        this.idleTimeout = idleTimeout;
         return this;
     }
 
@@ -376,6 +387,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
         return new ClientConfig(
                 serviceAddress,
                 requestTimeout,
+                idleTimeout,
                 maxRequestsPerBatch,
                 DefaultMaxBatchSize,
                 maxPendingBytes,

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -23,16 +23,18 @@ import io.oxia.client.metrics.Counter;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.client.metrics.Unit;
 import io.oxia.client.shard.ShardManager;
+import io.oxia.client.util.Watchdog;
 import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.NonNull;
 
 public class SequenceUpdates implements Closeable {
-
     private static final Logger log = Logger.get(SequenceUpdates.class);
 
     private final String key;
@@ -43,9 +45,13 @@ public class SequenceUpdates implements Closeable {
     private final ShardManager shardManager;
     private final Counter counterSequenceUpdatesReceived;
     private final Function<Void, Boolean> isClientClosed;
+    private final ScheduledExecutorService executor;
+    private final long refreshIntervalMillis;
+    private final Watchdog watchdog;
 
     private boolean closed = false;
     private CancelableStreamObserver<?> stream;
+    private volatile String lastDeliveredKey;
 
     SequenceUpdates(
             @NonNull String key,
@@ -54,13 +60,18 @@ public class SequenceUpdates implements Closeable {
             @NonNull RpcProvider rpcProvider,
             @NonNull ShardManager shardManager,
             @NonNull InstrumentProvider instrumentProvider,
-            Function<Void, Boolean> isClientClosed) {
+            Function<Void, Boolean> isClientClosed,
+            @NonNull ScheduledExecutorService executor,
+            @NonNull Duration refreshInterval) {
         this.key = key;
         this.partitionKey = partitionKey;
         this.listener = listener;
         this.rpcProvider = rpcProvider;
         this.shardManager = shardManager;
         this.isClientClosed = isClientClosed;
+        this.executor = executor;
+        this.refreshIntervalMillis = refreshInterval.toMillis();
+        this.watchdog = new Watchdog(executor, refreshInterval);
 
         this.counterSequenceUpdatesReceived =
                 instrumentProvider.newCounter(
@@ -75,6 +86,11 @@ public class SequenceUpdates implements Closeable {
     private synchronized void createStream() {
         if (closed) {
             return;
+        }
+
+        final var currentStream = stream;
+        if (currentStream != null) {
+            currentStream.cancel();
         }
 
         long shardId = shardManager.getShardForKey(partitionKey);
@@ -101,6 +117,7 @@ public class SequenceUpdates implements Closeable {
 
         stream = observer;
         rpcProvider.getSequenceUpdates(request, observer);
+        watchdog.start(this::refreshStream);
     }
 
     @Override
@@ -110,13 +127,22 @@ public class SequenceUpdates implements Closeable {
             closed = true;
             currentStream = stream;
         }
+        watchdog.close();
         if (currentStream != null) {
             currentStream.cancel();
         }
     }
 
     private void handleUpdate(@NonNull GetSequenceUpdatesResponse value) {
-        listener.accept(value.getHighestSequenceKey());
+        watchdog.pet();
+        final var key = value.getHighestSequenceKey();
+        if (key.equals(lastDeliveredKey)) {
+            // A recreated stream re-sends the current highest sequence key; it was already
+            // delivered, so skip the duplicate.
+            return;
+        }
+        lastDeliveredKey = key;
+        listener.accept(key);
         counterSequenceUpdatesReceived.increment();
     }
 
@@ -124,11 +150,33 @@ public class SequenceUpdates implements Closeable {
         if (closed || isClientClosed.apply(null)) {
             return;
         }
+        watchdog.pet();
         log.warn().exception(t).log("Failure while processing sequence updates");
         createStream();
     }
 
     private synchronized void handleCompleted() {
+        if (closed) {
+            return;
+        }
+        watchdog.pet();
+        createStream();
+    }
+
+    /**
+     * Recreates the stream, invoked by the watchdog when no update has been received for longer than
+     * the refresh interval.
+     *
+     * <p>An idle key is legitimately silent, so recreating the stream re-registers with the current
+     * leader and re-reads the current highest sequence key; duplicates are skipped by {@link
+     * #lastDeliveredKey}.
+     */
+    private void refreshStream() {
+        if (closed) {
+            return;
+        }
+        log.warn(
+                "No sequence updates received for " + refreshIntervalMillis + " ms, recreating the stream");
         createStream();
     }
 }

--- a/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
+++ b/client/src/main/java/io/oxia/client/SharedResourcesImpl.java
@@ -133,7 +133,8 @@ public class SharedResourcesImpl implements SharedResources {
                 RpcProvider.create(
                         config, executor, connectionManager, shardId -> shardManagerRef.get().leader(shardId));
         var shardManager =
-                new ShardManager(executor, rpcProvider, instrumentProvider, config.namespace());
+                new ShardManager(
+                        executor, rpcProvider, instrumentProvider, config.namespace(), config.idleTimeout());
         shardManagerRef.set(shardManager);
         return new SharedNamespace(rpcProvider, shardManager, shardManager.start());
     }
@@ -257,6 +258,7 @@ public class SharedResourcesImpl implements SharedResources {
                     new ClientConfig(
                             "shared",
                             OxiaClientBuilderImpl.DefaultRequestTimeout,
+                            OxiaClientBuilderImpl.DefaultIdleTimeout,
                             OxiaClientBuilderImpl.DefaultMaxRequestsPerBatch,
                             OxiaClientBuilderImpl.DefaultMaxBatchSize,
                             OxiaClientBuilderImpl.DefaultMaxPendingBytes,

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -106,8 +106,7 @@ final class GrpcRpcProvider implements RpcProvider {
     @Override
     public void getShardAssignments(
             @NonNull ShardAssignmentsRequest request,
-            @NonNull StreamObserver<ShardAssignments> observer) {
-        final var guardedObserver = ManagedObservers.toGuardedStreamObserver(observer);
+            @NonNull CancelableStreamObserver<ShardAssignments> observer) {
         try {
             Failsafe.with(getRetryPolicy("get shard assignments", null))
                     .with(asyncExecutor)
@@ -117,7 +116,7 @@ final class GrpcRpcProvider implements RpcProvider {
                                         new CompletableFuture<Void>()
                                                 .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var barrierObserver =
-                                        ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
+                                        ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
                                 try {
                                     connectionManager
                                             .getConnection(clientConfig.serviceAddress())
@@ -130,18 +129,18 @@ final class GrpcRpcProvider implements RpcProvider {
                             })
                     .exceptionally(
                             error -> {
-                                guardedObserver.onError(OxiaStatusException.from(error));
+                                observer.onError(OxiaStatusException.from(error));
                                 return null;
                             });
         } catch (Throwable error) {
-            guardedObserver.onError(OxiaStatusException.from(error));
+            observer.onError(OxiaStatusException.from(error));
         }
     }
 
     @Override
     public void getNotifications(
-            @NonNull NotificationsRequest request, @NonNull StreamObserver<NotificationBatch> observer) {
-        final var guardedObserver = ManagedObservers.toGuardedStreamObserver(observer);
+            @NonNull NotificationsRequest request,
+            @NonNull CancelableStreamObserver<NotificationBatch> observer) {
         final var hint = new AtomicReference<OxiaStatusException>();
         try {
             Failsafe.with(getRetryPolicy("get notifications", hint))
@@ -152,7 +151,7 @@ final class GrpcRpcProvider implements RpcProvider {
                                         new CompletableFuture<Void>()
                                                 .orTimeout(clientConfig.requestTimeout().toMillis(), TimeUnit.MILLISECONDS);
                                 final var barrierObserver =
-                                        ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
+                                        ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
                                 try {
                                     connectionManager
                                             .getConnection(getLeader(request.getShard(), hint))
@@ -165,11 +164,11 @@ final class GrpcRpcProvider implements RpcProvider {
                             })
                     .exceptionally(
                             error -> {
-                                guardedObserver.onError(OxiaStatusException.from(error));
+                                observer.onError(OxiaStatusException.from(error));
                                 return null;
                             });
         } catch (Throwable error) {
-            guardedObserver.onError(OxiaStatusException.from(error));
+            observer.onError(OxiaStatusException.from(error));
         }
     }
 

--- a/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/RpcProvider.java
@@ -48,10 +48,12 @@ public interface RpcProvider extends AutoCloseable {
     }
 
     void getShardAssignments(
-            @NonNull ShardAssignmentsRequest request, @NonNull StreamObserver<ShardAssignments> observer);
+            @NonNull ShardAssignmentsRequest request,
+            @NonNull CancelableStreamObserver<ShardAssignments> observer);
 
     void getNotifications(
-            @NonNull NotificationsRequest request, @NonNull StreamObserver<NotificationBatch> observer);
+            @NonNull NotificationsRequest request,
+            @NonNull CancelableStreamObserver<NotificationBatch> observer);
 
     CompletableFuture<CreateSessionResponse> createSession(@NonNull CreateSessionRequest request);
 

--- a/client/src/main/java/io/oxia/client/notify/NotificationManager.java
+++ b/client/src/main/java/io/oxia/client/notify/NotificationManager.java
@@ -24,6 +24,7 @@ import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.client.metrics.Unit;
 import io.oxia.client.shard.ShardManager;
 import io.oxia.client.shard.ShardManager.ShardAssignmentChanges;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -36,6 +37,8 @@ import lombok.Getter;
 import lombok.NonNull;
 
 public class NotificationManager implements AutoCloseable, Consumer<ShardAssignmentChanges> {
+    private static final Duration DEFAULT_REFRESH_INTERVAL = Duration.ofSeconds(90);
+
     private final ConcurrentMap<Long, ShardNotificationReceiver> shardReceivers =
             new ConcurrentHashMap<>();
     private final @NonNull ShardNotificationReceiver.Factory receiverFactory;
@@ -54,9 +57,18 @@ public class NotificationManager implements AutoCloseable, Consumer<ShardAssignm
             @NonNull RpcProvider rpcProvider,
             @NonNull ShardManager shardManager,
             @NonNull InstrumentProvider instrumentProvider) {
+        this(executor, rpcProvider, shardManager, instrumentProvider, DEFAULT_REFRESH_INTERVAL);
+    }
+
+    public NotificationManager(
+            @NonNull ScheduledExecutorService executor,
+            @NonNull RpcProvider rpcProvider,
+            @NonNull ShardManager shardManager,
+            @NonNull InstrumentProvider instrumentProvider,
+            @NonNull Duration refreshInterval) {
         this(
                 executor,
-                new ShardNotificationReceiver.Factory(rpcProvider),
+                new ShardNotificationReceiver.Factory(rpcProvider, refreshInterval),
                 shardManager,
                 instrumentProvider);
     }

--- a/client/src/main/java/io/oxia/client/notify/ShardNotificationReceiver.java
+++ b/client/src/main/java/io/oxia/client/notify/ShardNotificationReceiver.java
@@ -25,10 +25,13 @@ import io.oxia.client.api.Notification;
 import io.oxia.client.api.Notification.KeyCreated;
 import io.oxia.client.api.Notification.KeyDeleted;
 import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.grpc.observer.CancelableStreamObserver;
 import io.oxia.client.util.Backoff;
+import io.oxia.client.util.Watchdog;
 import io.oxia.proto.NotificationBatch;
 import io.oxia.proto.NotificationsRequest;
 import java.io.Closeable;
+import java.time.Duration;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -53,36 +56,70 @@ public class ShardNotificationReceiver implements Closeable, StreamObserver<Noti
     private volatile boolean closed = false;
 
     private final Backoff backoff = new Backoff();
+    private final long refreshIntervalMillis;
+    private final Watchdog watchdog;
+    private CancelableStreamObserver<NotificationBatch> stream;
 
     ShardNotificationReceiver(
             @NonNull RpcProvider rpcProvider,
             long shardId,
             @NonNull Consumer<Notification> callback,
             @NonNull NotificationManager notificationManager,
-            @NonNull OptionalLong offset) {
+            @NonNull OptionalLong offset,
+            @NonNull Duration refreshInterval) {
         this.rpcProvider = rpcProvider;
         this.notificationManager = notificationManager;
         this.shardId = shardId;
         this.callback = callback;
         this.offset = offset;
+        this.refreshIntervalMillis = refreshInterval.toMillis();
+        this.watchdog = new Watchdog(notificationManager.getExecutor(), refreshInterval);
         this.log = Logger.get(ShardNotificationReceiver.class).with().attr("shard", shardId).build();
 
         start();
     }
 
-    void start() {
+    synchronized void start() {
         var request = new NotificationsRequest();
         request.setShard(shardId);
         offset.ifPresent(request::setStartOffsetExclusive);
+
+        // Cancel any existing stream first so that the refresh and retry paths can never leave two
+        // concurrent streams registered for this shard.
+        final var currentStream = stream;
+        if (currentStream != null) {
+            currentStream.cancel();
+        }
+
+        stream =
+                new CancelableStreamObserver<NotificationBatch>() {
+                    @Override
+                    protected void handleNext(NotificationBatch value) {
+                        ShardNotificationReceiver.this.onNext(value);
+                    }
+
+                    @Override
+                    protected void handleError(Throwable t) {
+                        ShardNotificationReceiver.this.onError(t);
+                    }
+
+                    @Override
+                    protected void handleComplete() {
+                        ShardNotificationReceiver.this.onCompleted();
+                    }
+                };
         try {
-            rpcProvider.getNotifications(request, this);
+            rpcProvider.getNotifications(request, stream);
         } catch (Throwable ex) {
             onError(ex);
+            return;
         }
+        watchdog.start(this::refreshStream);
     }
 
     @Override
     public void onNext(NotificationBatch batch) {
+        watchdog.pet();
         if (offset.isPresent() && offset.getAsLong() >= batch.getOffset()) {
             // Ignore repeated notifications
             return;
@@ -119,6 +156,7 @@ public class ShardNotificationReceiver implements Closeable, StreamObserver<Noti
             return;
         }
 
+        watchdog.pet();
         long retryDelayMillis = backoff.nextDelayMillis();
         log.warn()
                 .attr("retryInSeconds", retryDelayMillis / 1000.0)
@@ -139,14 +177,38 @@ public class ShardNotificationReceiver implements Closeable, StreamObserver<Noti
 
     @Override
     public void onCompleted() {
-        if (!closed) {
-            start();
+        if (closed) {
+            return;
         }
+        watchdog.pet();
+        start();
+    }
+
+    /**
+     * Recreates the notifications stream, invoked by the refresh scheduler when no batch has been
+     * received for longer than the refresh interval.
+     *
+     * <p>Reconnecting resumes from the last received offset, so recreating an idle stream is
+     * lossless: the server re-delivers from that position and the client ignores repeated batches.
+     */
+    private void refreshStream() {
+        if (closed) {
+            return;
+        }
+
+        log.warn()
+                .attr("shard", shardId)
+                .log(
+                        "No notifications received for "
+                                + refreshIntervalMillis
+                                + " ms, recreating the stream");
+        start();
     }
 
     @RequiredArgsConstructor(access = PACKAGE)
     static class Factory {
         private final @NonNull RpcProvider rpcProvider;
+        private final @NonNull Duration refreshInterval;
 
         @Getter
         private final @NonNull CompositeConsumer<Notification> callback = new CompositeConsumer<>();
@@ -157,12 +219,17 @@ public class ShardNotificationReceiver implements Closeable, StreamObserver<Noti
                 @NonNull NotificationManager notificationManager,
                 @NonNull OptionalLong offset) {
             return new ShardNotificationReceiver(
-                    rpcProvider, shardId, callback, notificationManager, offset);
+                    rpcProvider, shardId, callback, notificationManager, offset, refreshInterval);
         }
     }
 
     @Override
     public void close() {
         this.closed = true;
+        watchdog.close();
+        final var currentStream = stream;
+        if (currentStream != null) {
+            currentStream.cancel();
+        }
     }
 }

--- a/client/src/main/java/io/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardManager.java
@@ -31,13 +31,16 @@ import io.opentelemetry.api.common.Attributes;
 import io.oxia.client.CompositeConsumer;
 import io.oxia.client.grpc.OxiaStatusException;
 import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.grpc.observer.CancelableStreamObserver;
 import io.oxia.client.metrics.Counter;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.client.metrics.Unit;
 import io.oxia.client.util.Backoff;
+import io.oxia.client.util.Watchdog;
 import io.oxia.proto.NamespaceShardsAssignment;
 import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -60,6 +63,12 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
     private final Backoff backoff = new Backoff();
     private final CompletableFuture<Void> initialAssignmentsFuture;
 
+    private static final Duration DEFAULT_REFRESH_INTERVAL = Duration.ofSeconds(90);
+
+    private final long refreshIntervalMillis;
+    private final Watchdog watchdog;
+    private CancelableStreamObserver<ShardAssignments> stream;
+
     private volatile boolean closed;
 
     private final Counter shardAssignmentsEvents;
@@ -69,11 +78,22 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
             @NonNull RpcProvider rpcProvider,
             @NonNull InstrumentProvider instrumentProvider,
             @NonNull String namespace) {
+        this(asyncExecutor, rpcProvider, instrumentProvider, namespace, DEFAULT_REFRESH_INTERVAL);
+    }
+
+    public ShardManager(
+            @NonNull ScheduledExecutorService asyncExecutor,
+            @NonNull RpcProvider rpcProvider,
+            @NonNull InstrumentProvider instrumentProvider,
+            @NonNull String namespace,
+            @NonNull Duration refreshInterval) {
         this.rpcProvider = rpcProvider;
         this.asyncExecutor = asyncExecutor;
         this.assignments = new ShardAssignmentsContainer(Xxh332HashRangeShardStrategy, namespace);
         this.callbacks = new CompositeConsumer<>();
         this.initialAssignmentsFuture = new CompletableFuture<>();
+        this.refreshIntervalMillis = refreshInterval.toMillis();
+        this.watchdog = new Watchdog(asyncExecutor, refreshInterval);
         this.log =
                 Logger.get(ShardManager.class).with().attr("namespace", assignments.getNamespace()).build();
 
@@ -88,18 +108,49 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
     @Override
     public void close() {
         closed = true;
+        watchdog.close();
+        final var currentStream = stream;
+        if (currentStream != null) {
+            currentStream.cancel();
+        }
     }
 
-    public CompletableFuture<Void> start() {
+    public synchronized CompletableFuture<Void> start() {
         var req = new ShardAssignmentsRequest();
         req.setNamespace(assignments.getNamespace());
 
-        rpcProvider.getShardAssignments(req, this);
+        // Cancel any existing stream first so that the refresh and retry paths can never leave two
+        // concurrent streams registered with the servers.
+        final var currentStream = stream;
+        if (currentStream != null) {
+            currentStream.cancel();
+        }
+
+        stream =
+                new CancelableStreamObserver<ShardAssignments>() {
+                    @Override
+                    protected void handleNext(ShardAssignments value) {
+                        ShardManager.this.onNext(value);
+                    }
+
+                    @Override
+                    protected void handleError(Throwable t) {
+                        ShardManager.this.onError(t);
+                    }
+
+                    @Override
+                    protected void handleComplete() {
+                        ShardManager.this.onCompleted();
+                    }
+                };
+        rpcProvider.getShardAssignments(req, stream);
+        watchdog.start(this::refreshStream);
         return initialAssignmentsFuture;
     }
 
     @Override
     public void onNext(ShardAssignments assignments) {
+        watchdog.pet();
         shardAssignmentsEvents.increment();
         updateAssignments(assignments);
         backoff.reset();
@@ -114,6 +165,7 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
             return;
         }
 
+        watchdog.pet();
         final var oxiaError = OxiaStatusException.from(error);
         if (oxiaError.getStatusCode() == NAMESPACE_NOT_FOUND && !initialAssignmentsFuture.isDone()) {
             log.error("Namespace not found");
@@ -141,6 +193,7 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
             return;
         }
 
+        watchdog.pet();
         log.warn("Stream closed while receiving shard assignments");
         asyncExecutor.schedule(
                 () -> {
@@ -151,6 +204,27 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
                 },
                 backoff.nextDelayMillis(),
                 TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Recreates the {@code GetShardAssignments} stream, invoked by the watchdog when no assignment
+     * update has been received for longer than the refresh interval.
+     *
+     * <p>The server pushes assignment updates periodically, so a healthy stream is never recreated. A
+     * stream that goes silent for longer than the interval is either half-open (its server-side
+     * handler died without delivering a terminal event) or silently stalled; cancelling it and
+     * opening a fresh stream re-registers with the current servers and receives the current snapshot.
+     */
+    private void refreshStream() {
+        if (closed) {
+            return;
+        }
+
+        log.warn(
+                "No shard assignments received for "
+                        + refreshIntervalMillis
+                        + " ms, recreating the stream");
+        start();
     }
 
     private void updateAssignments(io.oxia.proto.ShardAssignments shardAssignments) {

--- a/client/src/main/java/io/oxia/client/util/Watchdog.java
+++ b/client/src/main/java/io/oxia/client/util/Watchdog.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.util;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.NonNull;
+
+/**
+ * Fires a callback when no activity has been observed for a configurable interval.
+ *
+ * <p>Callers {@link #pet()} on every received message and register the callback to run when the
+ * stream has been silent too long (for example to recreate a long-lived stream whose server-side
+ * handler died without delivering a terminal event). The watchdog keeps running after the callback
+ * fires, so a stream that repeatedly goes silent is refreshed again.
+ */
+public final class Watchdog {
+    private final ScheduledExecutorService executor;
+    private final long intervalNanos;
+    private final AtomicBoolean started = new AtomicBoolean();
+
+    private volatile long lastActivityNanos;
+    private volatile ScheduledFuture<?> task;
+
+    public Watchdog(@NonNull ScheduledExecutorService executor, @NonNull Duration interval) {
+        this.executor = executor;
+        this.intervalNanos = interval.toNanos();
+        this.lastActivityNanos = System.nanoTime();
+    }
+
+    /** Records that a message was received, postponing the callback. */
+    public void pet() {
+        lastActivityNanos = System.nanoTime();
+    }
+
+    /** Starts the watchdog. The first invocation schedules the task; later calls are no-ops. */
+    public void start(@NonNull Runnable action) {
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+        task =
+                executor.scheduleWithFixedDelay(
+                        () -> checkForStaleActivity(action),
+                        intervalNanos / 2,
+                        intervalNanos / 2,
+                        TimeUnit.NANOSECONDS);
+    }
+
+    /** Stops the watchdog. */
+    public void close() {
+        final var current = task;
+        if (current != null) {
+            current.cancel(false);
+        }
+    }
+
+    private void checkForStaleActivity(@NonNull Runnable action) {
+        final long lastActivity = lastActivityNanos;
+        if (System.nanoTime() - lastActivity < intervalNanos) {
+            return;
+        }
+        // Reset first so a callback that does not deliver messages cannot be triggered repeatedly
+        // from the same stale activity timestamp.
+        lastActivityNanos = System.nanoTime();
+        action.run();
+    }
+}

--- a/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
+++ b/client/src/test/java/io/oxia/client/AsyncOxiaClientImplTest.java
@@ -94,6 +94,7 @@ class AsyncOxiaClientImplTest {
                 writeBatchManager,
                 sessionManager,
                 requestTimeout,
+                Duration.ofSeconds(90),
                 maxPendingBytes,
                 true);
     }

--- a/client/src/test/java/io/oxia/client/OxiaClientBuilderTest.java
+++ b/client/src/test/java/io/oxia/client/OxiaClientBuilderTest.java
@@ -43,6 +43,15 @@ class OxiaClientBuilderTest {
     }
 
     @Test
+    void idleTimeout() {
+        assertThatThrownBy(() -> builder.idleTimeout(ZERO))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.idleTimeout(Duration.ofMillis(-1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatNoException().isThrownBy(() -> builder.idleTimeout(Duration.ofMillis(1)));
+    }
+
+    @Test
     void batchLinger() {
         assertThatThrownBy(() -> builder.batchLinger(ZERO))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -84,6 +93,7 @@ class OxiaClientBuilderTest {
         Properties properties = new Properties();
         properties.setProperty("serviceAddress", "address:5678");
         properties.setProperty("requestTimeout", "1");
+        properties.setProperty("idleTimeout", "5");
         properties.setProperty("batchLinger", "2");
         properties.setProperty("maxRequestsPerBatch", "3");
         properties.setProperty("sessionTimeout", "4");
@@ -96,6 +106,7 @@ class OxiaClientBuilderTest {
         OxiaClientBuilderImpl impl = (OxiaClientBuilderImpl) builder;
         assertThat(impl.serviceAddress).isEqualTo("address:5678");
         assertThat(impl.requestTimeout).isEqualTo(Duration.ofMillis(1));
+        assertThat(impl.idleTimeout).isEqualTo(Duration.ofMillis(5));
         assertThat(impl.batchLinger).isEqualTo(Duration.ofMillis(2));
         assertThat(impl.maxRequestsPerBatch).isEqualTo(3);
         assertThat(impl.sessionTimeout).isEqualTo(Duration.ofMillis(4));

--- a/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
+++ b/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.grpc.observer.CancelableStreamObserver;
+import io.oxia.client.metrics.InstrumentProvider;
+import io.oxia.client.shard.ShardManager;
+import io.oxia.proto.GetSequenceUpdatesRequest;
+import io.oxia.proto.GetSequenceUpdatesResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class SequenceUpdatesTest {
+    @Test
+    void ignoresRedeliveredHighestSequenceKey() throws Exception {
+        var rpcProvider = mock(RpcProvider.class);
+        var shardManager = mock(ShardManager.class);
+        when(shardManager.getShardForKey(any())).thenReturn(0L);
+        var observerRef = new AtomicReference<CancelableStreamObserver<GetSequenceUpdatesResponse>>();
+        doAnswer(
+                        invocation -> {
+                            observerRef.set(invocation.getArgument(1));
+                            return null;
+                        })
+                .when(rpcProvider)
+                .getSequenceUpdates(any(GetSequenceUpdatesRequest.class), any());
+
+        var delivered = new ArrayList<String>();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        try (var updates =
+                new SequenceUpdates(
+                        "key",
+                        "partition",
+                        delivered::add,
+                        rpcProvider,
+                        shardManager,
+                        InstrumentProvider.NOOP,
+                        x -> false,
+                        executor,
+                        Duration.ofSeconds(90))) {
+            var observer = observerRef.get();
+            assertThat(observer).isNotNull();
+
+            var first =
+                    new GetSequenceUpdatesResponse().setHighestSequenceKey("key-00000000000000000001");
+            observer.onNext(first);
+            // A recreated stream re-sends the current highest key; it must be skipped.
+            observer.onNext(first);
+
+            assertThat(delivered).containsExactly("key-00000000000000000001");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchManagerTest.java
@@ -47,6 +47,7 @@ class BatchManagerTest {
             new ClientConfig(
                     "address",
                     Duration.ofMillis(100),
+                    Duration.ofSeconds(90),
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,

--- a/client/src/test/java/io/oxia/client/batch/BatchTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatchTest.java
@@ -102,6 +102,7 @@ class BatchTest {
             new ClientConfig(
                     "address",
                     Duration.ofMillis(100),
+                    Duration.ofSeconds(90),
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,
@@ -444,6 +445,7 @@ class BatchTest {
                     new ClientConfig(
                             "address",
                             Duration.ofMillis(100),
+                            Duration.ofSeconds(90),
                             10,
                             1024 * 1024,
                             256L * 1024 * 1024,
@@ -647,6 +649,7 @@ class BatchTest {
                     new ClientConfig(
                             "address",
                             Duration.ofMillis(100),
+                            Duration.ofSeconds(90),
                             10,
                             1024 * 1024,
                             256L * 1024 * 1024,
@@ -744,6 +747,7 @@ class BatchTest {
                 new ClientConfig(
                         "address",
                         ZERO,
+                        Duration.ofSeconds(90),
                         1,
                         1024 * 1024,
                         256L * 1024 * 1024,

--- a/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherPoolTest.java
@@ -48,6 +48,7 @@ class BatcherPoolTest {
             new ClientConfig(
                     "address",
                     Duration.ofMillis(100),
+                    Duration.ofSeconds(90),
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,

--- a/client/src/test/java/io/oxia/client/batch/BatcherTest.java
+++ b/client/src/test/java/io/oxia/client/batch/BatcherTest.java
@@ -49,6 +49,7 @@ class BatcherTest {
             new ClientConfig(
                     "address",
                     Duration.ofMillis(100),
+                    Duration.ofSeconds(90),
                     10,
                     1024 * 1024,
                     256L * 1024 * 1024,

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -27,6 +27,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.protobuf.StatusProto;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.OxiaClientBuilderImpl;
 import io.oxia.client.api.OxiaClientBuilder;
@@ -259,20 +260,7 @@ class GrpcRpcProviderTest {
             request.setShard(1);
             var notification = new AtomicReference<NotificationBatch>();
 
-            provider.getNotifications(
-                    request,
-                    new StreamObserver<>() {
-                        @Override
-                        public void onNext(NotificationBatch value) {
-                            notification.set(value);
-                        }
-
-                        @Override
-                        public void onError(Throwable t) {}
-
-                        @Override
-                        public void onCompleted() {}
-                    });
+            provider.getNotifications(request, capturingCancelableObserver(notification));
 
             await()
                     .untilAsserted(
@@ -755,18 +743,18 @@ class GrpcRpcProviderTest {
         try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
             provider.getShardAssignments(
                     new ShardAssignmentsRequest(),
-                    new StreamObserver<>() {
+                    new CancelableStreamObserver<>() {
                         @Override
-                        public void onNext(ShardAssignments value) {}
+                        protected void handleNext(ShardAssignments value) {}
 
                         @Override
-                        public void onError(Throwable t) {
+                        protected void handleError(Throwable t) {
                             error.set(t);
                             terminated.countDown();
                         }
 
                         @Override
-                        public void onCompleted() {
+                        protected void handleComplete() {
                             terminated.countDown();
                         }
                     });
@@ -775,6 +763,56 @@ class GrpcRpcProviderTest {
             assertThat(error.get()).isInstanceOf(OxiaStatusException.class);
             assertThat(((OxiaStatusException) error.get()).getStatusCode())
                     .isEqualTo(OxiaStatusCode.TIMEOUT);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void callerCanCancelShardAssignmentsStream() throws Exception {
+        var serverCallRef = new AtomicReference<ServerCallStreamObserver<ShardAssignments>>();
+        Server server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getShardAssignments(
+                                            ShardAssignmentsRequest request,
+                                            StreamObserver<ShardAssignments> responseObserver) {
+                                        serverCallRef.set(
+                                                (ServerCallStreamObserver<ShardAssignments>) responseObserver);
+                                        try {
+                                            new CountDownLatch(1).await();
+                                        } catch (InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config = ((OxiaClientBuilderImpl) OxiaClientBuilder.create(address)).getClientConfig();
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            var observer =
+                    new CancelableStreamObserver<ShardAssignments>() {
+                        @Override
+                        protected void handleNext(ShardAssignments value) {}
+
+                        @Override
+                        protected void handleError(Throwable t) {}
+
+                        @Override
+                        protected void handleComplete() {}
+                    };
+            provider.getShardAssignments(new ShardAssignmentsRequest(), observer);
+
+            await().until(() -> serverCallRef.get() != null);
+            observer.cancel();
+
+            await().untilAsserted(() -> assertThat(serverCallRef.get().isCancelled()).isTrue());
         } finally {
             executor.shutdownNow();
             server.shutdownNow();
@@ -819,21 +857,21 @@ class GrpcRpcProviderTest {
         try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
             provider.getShardAssignments(
                     new ShardAssignmentsRequest(),
-                    new StreamObserver<>() {
+                    new CancelableStreamObserver<>() {
                         @Override
-                        public void onNext(ShardAssignments value) {
+                        protected void handleNext(ShardAssignments value) {
                             received.incrementAndGet();
                         }
 
                         @Override
-                        public void onError(Throwable t) {
+                        protected void handleError(Throwable t) {
                             error.set(t);
                             terminalEvents.incrementAndGet();
                             terminated.countDown();
                         }
 
                         @Override
-                        public void onCompleted() {
+                        protected void handleComplete() {
                             terminalEvents.incrementAndGet();
                             terminated.countDown();
                         }
@@ -890,21 +928,21 @@ class GrpcRpcProviderTest {
         try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
             provider.getShardAssignments(
                     new ShardAssignmentsRequest(),
-                    new StreamObserver<>() {
+                    new CancelableStreamObserver<>() {
                         @Override
-                        public void onNext(ShardAssignments value) {
+                        protected void handleNext(ShardAssignments value) {
                             if (received.incrementAndGet() == 2) {
                                 secondMessage.countDown();
                             }
                         }
 
                         @Override
-                        public void onError(Throwable t) {
+                        protected void handleError(Throwable t) {
                             error.set(t);
                         }
 
                         @Override
-                        public void onCompleted() {}
+                        protected void handleComplete() {}
                     });
 
             await().untilAsserted(() -> assertThat(received.get()).isEqualTo(1));
@@ -954,18 +992,18 @@ class GrpcRpcProviderTest {
             request.setShard(1);
             provider.getNotifications(
                     request,
-                    new StreamObserver<>() {
+                    new CancelableStreamObserver<>() {
                         @Override
-                        public void onNext(NotificationBatch value) {}
+                        protected void handleNext(NotificationBatch value) {}
 
                         @Override
-                        public void onError(Throwable t) {
+                        protected void handleError(Throwable t) {
                             error.set(t);
                             terminated.countDown();
                         }
 
                         @Override
-                        public void onCompleted() {
+                        protected void handleComplete() {
                             terminated.countDown();
                         }
                     });
@@ -1014,18 +1052,18 @@ class GrpcRpcProviderTest {
             request.setStartOffsetExclusive(5);
             provider.getNotifications(
                     request,
-                    new StreamObserver<>() {
+                    new CancelableStreamObserver<>() {
                         @Override
-                        public void onNext(NotificationBatch value) {}
+                        protected void handleNext(NotificationBatch value) {}
 
                         @Override
-                        public void onError(Throwable t) {
+                        protected void handleError(Throwable t) {
                             error.set(t);
                             terminated.countDown();
                         }
 
                         @Override
-                        public void onCompleted() {
+                        protected void handleComplete() {
                             terminated.countDown();
                         }
                     });

--- a/client/src/test/java/io/oxia/client/notify/ShardNotificationReceiverTest.java
+++ b/client/src/test/java/io/oxia/client/notify/ShardNotificationReceiverTest.java
@@ -42,6 +42,7 @@ import io.oxia.client.metrics.Counter;
 import io.oxia.proto.NotificationBatch;
 import io.oxia.proto.NotificationsRequest;
 import io.oxia.proto.OxiaClientGrpc;
+import java.time.Duration;
 import java.util.OptionalLong;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -94,11 +95,14 @@ class ShardNotificationReceiverTest {
     @Mock RpcProvider rpcProvider;
     @Mock Consumer<Notification> notificationCallback;
     @Mock NotificationManager notificationManager;
+    ScheduledExecutorService executor;
 
     @BeforeEach
     void beforeEach() throws Exception {
         requests.set(0);
         responses.clear();
+        executor = Executors.newSingleThreadScheduledExecutor();
+        when(notificationManager.getExecutor()).thenReturn(executor);
         server =
                 InProcessServerBuilder.forName(serverName)
                         .directExecutor()
@@ -118,6 +122,7 @@ class ShardNotificationReceiverTest {
 
     @AfterEach
     void afterEach() throws Exception {
+        executor.shutdownNow();
         channel.shutdownNow();
         server.shutdownNow();
     }
@@ -139,7 +144,8 @@ class ShardNotificationReceiverTest {
                         shardId,
                         notificationCallback,
                         notificationManager,
-                        OptionalLong.empty())) {
+                        OptionalLong.empty(),
+                        Duration.ofSeconds(90))) {
             await()
                     .untilAsserted(
                             () -> {
@@ -159,7 +165,8 @@ class ShardNotificationReceiverTest {
                         shardId,
                         notificationCallback,
                         notificationManager,
-                        OptionalLong.empty())) {
+                        OptionalLong.empty(),
+                        Duration.ofSeconds(90))) {
             await()
                     .untilAsserted(
                             () -> {
@@ -186,7 +193,8 @@ class ShardNotificationReceiverTest {
                         shardId,
                         notificationCallback,
                         notificationManager,
-                        OptionalLong.empty())) {
+                        OptionalLong.empty(),
+                        Duration.ofSeconds(90))) {
             await()
                     .untilAsserted(
                             () -> {
@@ -209,7 +217,8 @@ class ShardNotificationReceiverTest {
                         shardId,
                         notificationCallback,
                         notificationManager,
-                        OptionalLong.empty())) {
+                        OptionalLong.empty(),
+                        Duration.ofSeconds(90))) {
             await()
                     .untilAsserted(
                             () -> {
@@ -217,6 +226,27 @@ class ShardNotificationReceiverTest {
                             });
         }
         assertThat(requests).hasValue(2);
+    }
+
+    @Test
+    void reconnectsWhenNoBatchesReceived() throws Exception {
+        when(notificationManager.getCounterNotificationsReceived()).thenReturn(mock(Counter.class));
+        when(notificationManager.getCounterNotificationsBatchesReceived())
+                .thenReturn(mock(Counter.class));
+
+        responses.add(new NotificationWrapper(newNotificationBatch("key1", created(1L)), null, false));
+
+        try (var receiver =
+                new ShardNotificationReceiver(
+                        rpcProvider,
+                        shardId,
+                        notificationCallback,
+                        notificationManager,
+                        OptionalLong.empty(),
+                        Duration.ofMillis(200))) {
+            // After the initial batch the stream goes silent, so the watchdog reconnects.
+            await().untilAsserted(() -> assertThat(requests.get()).isGreaterThanOrEqualTo(2));
+        }
     }
 
     static NotificationBatch newNotificationBatch(

--- a/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionManagerTest.java
@@ -61,6 +61,7 @@ class SessionManagerTest {
                 new ClientConfig(
                         "address",
                         Duration.ofSeconds(1),
+                        Duration.ofSeconds(90),
                         1,
                         1024,
                         256L * 1024 * 1024,

--- a/client/src/test/java/io/oxia/client/session/SessionTest.java
+++ b/client/src/test/java/io/oxia/client/session/SessionTest.java
@@ -69,6 +69,7 @@ class SessionTest {
                 new ClientConfig(
                         "address",
                         Duration.ZERO,
+                        Duration.ofSeconds(90),
                         1,
                         1024 * 1024,
                         256L * 1024 * 1024,

--- a/client/src/test/java/io/oxia/client/shard/ShardManagerGrpcTest.java
+++ b/client/src/test/java/io/oxia/client/shard/ShardManagerGrpcTest.java
@@ -29,6 +29,7 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.grpc.observer.CancelableStreamObserver;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.proto.OxiaClientGrpc;
 import io.oxia.proto.ShardAssignment;
@@ -116,7 +117,7 @@ class ShardManagerGrpcTest {
                 .when(rpcProvider)
                 .getShardAssignments(
                         org.mockito.ArgumentMatchers.any(ShardAssignmentsRequest.class),
-                        org.mockito.ArgumentMatchers.any(StreamObserver.class));
+                        org.mockito.ArgumentMatchers.any(CancelableStreamObserver.class));
     }
 
     @AfterEach

--- a/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
+++ b/client/src/test/java/io/oxia/client/shard/ShardManagerTest.java
@@ -19,8 +19,8 @@ import static io.oxia.client.OxiaClientBuilderImpl.DefaultNamespace;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
@@ -28,11 +28,13 @@ import io.grpc.Status;
 import io.oxia.client.grpc.OxiaStatusCode;
 import io.oxia.client.grpc.OxiaStatusException;
 import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.grpc.observer.CancelableStreamObserver;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.proto.ShardAssignment;
 import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -165,7 +167,8 @@ public class ShardManagerTest {
                                 return null;
                             })
                     .when(rpcProvider)
-                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+                    .getShardAssignments(
+                            any(ShardAssignmentsRequest.class), any(CancelableStreamObserver.class));
 
             var future = manager.start();
             assertThat(future).succeedsWithin(Duration.ofSeconds(1));
@@ -195,13 +198,134 @@ public class ShardManagerTest {
                                 return null;
                             })
                     .when(rpcProvider)
-                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+                    .getShardAssignments(
+                            any(ShardAssignmentsRequest.class), any(CancelableStreamObserver.class));
 
             assertThat(manager.start()).succeedsWithin(Duration.ofSeconds(1));
 
             verify(rpcProvider, org.mockito.Mockito.times(2))
-                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+                    .getShardAssignments(
+                            any(ShardAssignmentsRequest.class), any(CancelableStreamObserver.class));
             assertThat(stubCalls).hasValue(2);
+        }
+
+        @Test
+        void recreatesStreamWhenAssignmentsGoSilent() {
+            var stubCalls = new AtomicInteger();
+            manager =
+                    new ShardManager(
+                            asyncExecutor,
+                            rpcProvider,
+                            InstrumentProvider.NOOP,
+                            DefaultNamespace,
+                            Duration.ofMillis(200));
+
+            var assignment = new ShardAssignment();
+            assignment.setShard(0).setLeader("leader0");
+            assignment.setInt32HashRange().setMinHashInclusive(0).setMaxHashInclusive(Integer.MAX_VALUE);
+
+            doAnswer(
+                            invocation -> {
+                                stubCalls.incrementAndGet();
+                                var sa = new ShardAssignments();
+                                sa.putNamespaces(namespace).addAssignment().copyFrom(assignment);
+                                ((CancelableStreamObserver<ShardAssignments>) invocation.getArgument(1)).onNext(sa);
+                                return null;
+                            })
+                    .when(rpcProvider)
+                    .getShardAssignments(
+                            any(ShardAssignmentsRequest.class), any(CancelableStreamObserver.class));
+
+            assertThat(manager.start()).succeedsWithin(Duration.ofSeconds(1));
+            assertThat(manager.leader(0)).isEqualTo("leader0");
+
+            // After the initial snapshot the stream goes silent, so the watchdog recreates it.
+            await().untilAsserted(() -> assertThat(stubCalls.get()).isGreaterThanOrEqualTo(2));
+        }
+
+        @Test
+        void doesNotRecreateStreamWhileAssignmentsKeepArriving() throws Exception {
+            manager =
+                    new ShardManager(
+                            asyncExecutor,
+                            rpcProvider,
+                            InstrumentProvider.NOOP,
+                            DefaultNamespace,
+                            Duration.ofMillis(200));
+            var observers = new ArrayList<CancelableStreamObserver<ShardAssignments>>();
+            doAnswer(
+                            invocation -> {
+                                observers.add(invocation.getArgument(1));
+                                return null;
+                            })
+                    .when(rpcProvider)
+                    .getShardAssignments(
+                            any(ShardAssignmentsRequest.class), any(CancelableStreamObserver.class));
+
+            var assignment = new ShardAssignment();
+            assignment.setShard(0).setLeader("leader0");
+            assignment.setInt32HashRange().setMinHashInclusive(0).setMaxHashInclusive(Integer.MAX_VALUE);
+            var snapshot = new ShardAssignments();
+            snapshot.putNamespaces(namespace).addAssignment().copyFrom(assignment);
+
+            var future = manager.start();
+            await().until(() -> observers.size() == 1);
+            observers.get(0).onNext(snapshot);
+            assertThat(future).succeedsWithin(Duration.ofSeconds(1));
+
+            for (int i = 0; i < 8; i++) {
+                Thread.sleep(60);
+                observers.get(0).onNext(snapshot);
+            }
+            assertThat(observers.size()).isEqualTo(1);
+        }
+
+        @Test
+        void cancelsPreviousStreamBeforeRecreating() {
+            manager =
+                    new ShardManager(
+                            asyncExecutor,
+                            rpcProvider,
+                            InstrumentProvider.NOOP,
+                            DefaultNamespace,
+                            Duration.ofMillis(200));
+            var observers = new ArrayList<CancelableStreamObserver<ShardAssignments>>();
+
+            var assignment = new ShardAssignment();
+            assignment.setShard(0).setLeader("leader0");
+            assignment.setInt32HashRange().setMinHashInclusive(0).setMaxHashInclusive(Integer.MAX_VALUE);
+            var staleAssignment = new ShardAssignment();
+            staleAssignment.setShard(0).setLeader("leader1");
+            staleAssignment
+                    .setInt32HashRange()
+                    .setMinHashInclusive(0)
+                    .setMaxHashInclusive(Integer.MAX_VALUE);
+
+            doAnswer(
+                            invocation -> {
+                                var observer =
+                                        (CancelableStreamObserver<ShardAssignments>) invocation.getArgument(1);
+                                observers.add(observer);
+                                var sa = new ShardAssignments();
+                                sa.putNamespaces(namespace).addAssignment().copyFrom(assignment);
+                                observer.onNext(sa);
+                                return null;
+                            })
+                    .when(rpcProvider)
+                    .getShardAssignments(
+                            any(ShardAssignmentsRequest.class), any(CancelableStreamObserver.class));
+
+            assertThat(manager.start()).succeedsWithin(Duration.ofSeconds(1));
+            assertThat(manager.leader(0)).isEqualTo("leader0");
+
+            await().untilAsserted(() -> assertThat(observers.size()).isGreaterThanOrEqualTo(2));
+
+            // The old stream was cancelled before recreating, so a stale snapshot delivered through
+            // it must be ignored.
+            var stale = new ShardAssignments();
+            stale.putNamespaces(namespace).addAssignment().copyFrom(staleAssignment);
+            observers.get(0).onNext(stale);
+            assertThat(manager.leader(0)).isEqualTo("leader0");
         }
 
         @Test
@@ -247,7 +371,8 @@ public class ShardManagerTest {
                                 return null;
                             })
                     .when(rpcProvider)
-                    .getShardAssignments(any(ShardAssignmentsRequest.class), eq(manager));
+                    .getShardAssignments(
+                            any(ShardAssignmentsRequest.class), any(CancelableStreamObserver.class));
 
             assertThat(manager.start()).succeedsWithin(Duration.ofSeconds(1));
             assertThat(manager.allShardIds()).containsExactly(0L);

--- a/client/src/test/java/io/oxia/client/util/WatchdogTest.java
+++ b/client/src/test/java/io/oxia/client/util/WatchdogTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WatchdogTest {
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    @AfterEach
+    void cleanup() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    void firesActionWhenIdlePastInterval() {
+        var actions = new AtomicInteger();
+        var watchdog = new Watchdog(executor, Duration.ofMillis(200));
+        watchdog.start(actions::incrementAndGet);
+
+        await().untilAsserted(() -> assertThat(actions.get()).isGreaterThanOrEqualTo(1));
+    }
+
+    @Test
+    void doesNotFireWhileActivityContinues() throws Exception {
+        var actions = new AtomicInteger();
+        var watchdog = new Watchdog(executor, Duration.ofMillis(200));
+        watchdog.start(actions::incrementAndGet);
+
+        for (int i = 0; i < 10; i++) {
+            Thread.sleep(50);
+            watchdog.pet();
+        }
+
+        assertThat(actions.get()).isZero();
+    }
+
+    @Test
+    void closeStopsTheWatchdog() throws Exception {
+        var actions = new AtomicInteger();
+        var watchdog = new Watchdog(executor, Duration.ofMillis(100));
+        watchdog.start(actions::incrementAndGet);
+        Thread.sleep(500);
+        assertThat(actions.get()).isGreaterThanOrEqualTo(1);
+
+        watchdog.close();
+        var fired = actions.get();
+        Thread.sleep(500);
+        assertThat(actions.get()).isEqualTo(fired);
+    }
+}


### PR DESCRIPTION
## Motivation

Long-lived streams (shard assignments, notifications, sequence updates) can go silent without ever delivering a terminal event — for example when the server-side handler dies behind an L7 proxy that answers transport keepalives locally. The client then keeps a stale assignment snapshot, misses notifications, or misses sequence updates indefinitely. The establishment timeout (#370) bounds the first message; this PR bounds the *lifetime* of a silent stream by recreating it when no message has been received for a configurable interval.

## Modifications

- Add `io.oxia.client.util.Watchdog`: callers `pet()` on every received message and register the action to run when the stream has been silent too long; idempotent start, cancellable close.
- Add the `idleTimeout` client option (default 90s) on `OxiaClientBuilder`, plumbed through `ClientConfig` into `ShardManager`, `NotificationManager` and `SequenceUpdates`.
- `ShardManager` recreates the shard-assignments stream after `idleTimeout` without an update (safe: the server pushes every ~25–35s, so healthy streams never trigger).
- `ShardNotificationReceiver` recreates idle notification streams per shard; reconnects resume from the last received offset, so they are lossless and repeated batches are deduplicated.
- `SequenceUpdates` recreates idle streams and skips the highest sequence key that a recreated stream re-sends, so the listener never sees duplicates.
- `getShardAssignments`/`getNotifications` now take caller-owned `CancelableStreamObserver`s (consistent with `list`/`rangeScan`/`getSequenceUpdates`): each consumer holds and cancels its own stream before recreating it, so a refresh never leaves two concurrent streams registered, and the provider keeps no references to active streams.

## Testing

- `WatchdogTest`: fires when idle, not while activity continues, stops on close.
- `ShardManagerTest`: recreates the stream after silence, does not recreate while snapshots keep arriving, and cancels the previous stream before recreating (a stale snapshot delivered through the old stream is ignored).
- `ShardNotificationReceiverTest`: reconnects after the refresh interval without batches.
- `SequenceUpdatesTest`: re-delivered highest sequence key is skipped.
- `GrpcRpcProviderTest`: a caller-owned stream can be cancelled and the server observes the cancellation.
- `OxiaClientBuilderTest`: `idleTimeout` validation and `loadConfig` property.
- `./gradlew :client:test` passes for all unit tests; the only failures in the full suite are the pre-existing Testcontainers integration tests that require Docker (unavailable in this environment).
- `./gradlew spotlessCheck` passes.