### PR TITLE
fix: recover stalled client subscriptions

### DIFF
--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -260,6 +260,44 @@ public interface OxiaClientBuilder {
     OxiaClientBuilder connectionKeepAliveTime(Duration connectionKeepAlive);
 
     /**
+     * Configure the maximum age of long-lived subscriptions.
+     *
+     * <p>Here, a subscription means a client operation that continuously receives shard assignments,
+     * notifications, or sequence updates. This setting does not expose the underlying transport and
+     * is not an inactivity timeout. The client transparently renews each subscription at a random age
+     * between half this value and this value, even when it is healthy.
+     *
+     * <p>Bounding the age lets the client recover when an intermediary loses its upstream connection
+     * while leaving the downstream connection apparently healthy. Randomization spreads renewals
+     * across clients, following the Kubernetes {@code client-go} Reflector pattern.
+     *
+     * <p>Renewal preserves logical progress: shard assignments restart from a complete snapshot,
+     * notifications continue after the last received offset, and sequence updates suppress the
+     * repeated current key returned when they restart.
+     *
+     * <p>Default is <code>10 minutes</code>, resulting in subscription ages between 5 and 10 minutes.
+     * Calling this method also re-enables the maximum age if it was previously disabled with {@link
+     * #disableSubscriptionMaxAge()}.
+     *
+     * @param subscriptionMaxAge the upper bound for a subscription's randomized age
+     * @return the builder instance
+     * @see <a
+     *     href="https://github.com/kubernetes/client-go/blob/master/tools/cache/reflector.go">Kubernetes
+     *     client-go Reflector</a>
+     */
+    OxiaClientBuilder subscriptionMaxAge(Duration subscriptionMaxAge);
+
+    /**
+     * Disable the maximum age for long-lived subscriptions.
+     *
+     * <p>With the maximum age disabled, a subscription can appear healthy indefinitely if an
+     * intermediary loses its upstream connection while keeping the downstream HTTP/2 connection open.
+     *
+     * @return the builder instance
+     */
+    OxiaClientBuilder disableSubscriptionMaxAge();
+
+    /**
      * Configure the authentication plugin and its parameters.
      *
      * @param authPluginClassName the class name of the authentication plugin

--- a/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
+++ b/client-api/src/main/java/io/oxia/client/api/OxiaClientBuilder.java
@@ -272,8 +272,8 @@ public interface OxiaClientBuilder {
      * across clients, following the Kubernetes {@code client-go} Reflector pattern.
      *
      * <p>Renewal preserves logical progress: shard assignments restart from a complete snapshot,
-     * notifications continue after the last received offset, and sequence updates suppress the
-     * repeated current key returned when they restart.
+     * notifications continue after the last received offset, and sequence updates restart by
+     * reporting the current highest key, which can replay the most recently reported key.
      *
      * <p>Default is <code>10 minutes</code>, resulting in subscription ages between 5 and 10 minutes.
      * Calling this method also re-enables the maximum age if it was previously disabled with {@link

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -795,7 +795,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 this.rpcProvider,
                 this.shardManager,
                 this.instrumentProvider,
-                () -> closed,
+                x -> closed,
                 this.scheduledExecutor);
     }
 

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -795,7 +795,8 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 this.rpcProvider,
                 this.shardManager,
                 this.instrumentProvider,
-                x -> closed);
+                x -> closed,
+                this.scheduledExecutor);
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
+++ b/client/src/main/java/io/oxia/client/AsyncOxiaClientImpl.java
@@ -795,7 +795,7 @@ class AsyncOxiaClientImpl implements AsyncOxiaClient {
                 this.rpcProvider,
                 this.shardManager,
                 this.instrumentProvider,
-                x -> closed,
+                () -> closed,
                 this.scheduledExecutor);
     }
 

--- a/client/src/main/java/io/oxia/client/ClientConfig.java
+++ b/client/src/main/java/io/oxia/client/ClientConfig.java
@@ -40,4 +40,49 @@ public record ClientConfig(
         @NonNull Duration connectionBackoffMaxDelay,
         Duration connectionKeepAliveTime,
         Duration connectionKeepAliveTimeout,
-        int maxConnectionPerNode) {}
+        int maxConnectionPerNode,
+        @Nullable Duration subscriptionMaxAge) {
+
+    public ClientConfig(
+            @NonNull String serviceAddress,
+            @NonNull Duration requestTimeout,
+            int maxRequestsPerBatch,
+            int maxBatchSize,
+            long maxPendingBytes,
+            int maxWriteBatchesInFlight,
+            int maxReadBatchesInFlight,
+            int batchingThreads,
+            @NonNull Duration sessionTimeout,
+            @NonNull String clientIdentifier,
+            OpenTelemetry openTelemetry,
+            @NonNull String namespace,
+            @Nullable Authentication authentication,
+            boolean enableTls,
+            @NonNull Duration connectionBackoffMinDelay,
+            @NonNull Duration connectionBackoffMaxDelay,
+            Duration connectionKeepAliveTime,
+            Duration connectionKeepAliveTimeout,
+            int maxConnectionPerNode) {
+        this(
+                serviceAddress,
+                requestTimeout,
+                maxRequestsPerBatch,
+                maxBatchSize,
+                maxPendingBytes,
+                maxWriteBatchesInFlight,
+                maxReadBatchesInFlight,
+                batchingThreads,
+                sessionTimeout,
+                clientIdentifier,
+                openTelemetry,
+                namespace,
+                authentication,
+                enableTls,
+                connectionBackoffMinDelay,
+                connectionBackoffMaxDelay,
+                connectionKeepAliveTime,
+                connectionKeepAliveTimeout,
+                maxConnectionPerNode,
+                OxiaClientBuilderImpl.DefaultSubscriptionMaxAge);
+    }
+}

--- a/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
+++ b/client/src/main/java/io/oxia/client/OxiaClientBuilderImpl.java
@@ -57,6 +57,7 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     public static final int DefaultBatchingThreads = 1;
     public static final Duration DefaultRequestTimeout = Duration.ofSeconds(30);
     public static final Duration DefaultSessionTimeout = Duration.ofSeconds(15);
+    public static final Duration DefaultSubscriptionMaxAge = Duration.ofMinutes(10);
     public static final String DefaultNamespace = "default";
     public static final boolean DefaultEnableTls = false;
     public static final int DefaultMaxConnectionPerNode = 1;
@@ -91,6 +92,8 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
 
     protected Duration connectionKeepAliveTime = Duration.ofSeconds(10);
     protected Duration connectionKeepAliveTimeout = Duration.ofSeconds(3);
+
+    @Nullable protected Duration subscriptionMaxAge = DefaultSubscriptionMaxAge;
 
     protected int maxConnectionsPerNode = DefaultMaxConnectionPerNode;
 
@@ -253,6 +256,29 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
     }
 
     @Override
+    public OxiaClientBuilder subscriptionMaxAge(@NonNull Duration subscriptionMaxAge) {
+        final long maxAgeMillis;
+        try {
+            maxAgeMillis = subscriptionMaxAge.toMillis();
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException(
+                    "subscriptionMaxAge is too large: " + subscriptionMaxAge, e);
+        }
+        if (maxAgeMillis < 2) {
+            throw new IllegalArgumentException(
+                    "subscriptionMaxAge must be at least 2 ms: " + subscriptionMaxAge);
+        }
+        this.subscriptionMaxAge = subscriptionMaxAge;
+        return this;
+    }
+
+    @Override
+    public OxiaClientBuilder disableSubscriptionMaxAge() {
+        this.subscriptionMaxAge = null;
+        return this;
+    }
+
+    @Override
     public OxiaClientBuilder authentication(String authPluginClassName, String authParamsString)
             throws UnsupportedAuthenticationException {
         this.authPluginClassName = authPluginClassName;
@@ -392,7 +418,8 @@ public class OxiaClientBuilderImpl implements OxiaClientBuilder {
                 connectionBackoffMaxDelay,
                 connectionKeepAliveTime,
                 connectionKeepAliveTimeout,
-                maxConnectionsPerNode);
+                maxConnectionsPerNode,
+                subscriptionMaxAge);
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -30,9 +30,10 @@ import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.NonNull;
 
 public class SequenceUpdates implements Closeable {
@@ -46,7 +47,7 @@ public class SequenceUpdates implements Closeable {
     private final RpcProvider rpcProvider;
     private final ShardManager shardManager;
     private final Counter counterSequenceUpdatesReceived;
-    private final BooleanSupplier isClientClosed;
+    private final Function<Void, Boolean> isClientClosed;
     private final ScheduledExecutorService executor;
 
     private boolean closed = false;
@@ -60,7 +61,7 @@ public class SequenceUpdates implements Closeable {
             @NonNull RpcProvider rpcProvider,
             @NonNull ShardManager shardManager,
             @NonNull InstrumentProvider instrumentProvider,
-            @NonNull BooleanSupplier isClientClosed,
+            Function<Void, Boolean> isClientClosed,
             @NonNull ScheduledExecutorService executor) {
         this.key = key;
         this.partitionKey = partitionKey;
@@ -81,7 +82,7 @@ public class SequenceUpdates implements Closeable {
     }
 
     private synchronized void createStream() {
-        if (closed || isClientClosed.getAsBoolean()) {
+        if (closed || isClientClosed.apply(null)) {
             return;
         }
 
@@ -142,7 +143,7 @@ public class SequenceUpdates implements Closeable {
     }
 
     private synchronized void handleError(@NonNull Throwable t) {
-        if (closed || isClientClosed.getAsBoolean()) {
+        if (closed || isClientClosed.apply(null)) {
             return;
         }
         if (Status.fromThrowable(getRootCause(t)).getCode() == Status.Code.DEADLINE_EXCEEDED) {
@@ -150,17 +151,26 @@ public class SequenceUpdates implements Closeable {
         } else {
             log.warn().exception(t).log("Failure while processing sequence updates");
         }
-        scheduleRestart();
+        try {
+            executor.execute(this::createStream);
+        } catch (RejectedExecutionException e) {
+            if (!closed && !isClientClosed.apply(null)) {
+                log.warn().exception(e).log("Failed to schedule sequence updates subscription restart");
+            }
+        }
     }
 
     private synchronized void handleCompleted() {
-        if (closed || isClientClosed.getAsBoolean()) {
+        if (closed || isClientClosed.apply(null)) {
             return;
         }
-        scheduleRestart();
-    }
-
-    private void scheduleRestart() {
-        executor.execute(this::createStream);
+        log.warn("Stream closed while receiving sequence updates");
+        try {
+            executor.execute(this::createStream);
+        } catch (RejectedExecutionException e) {
+            if (!closed && !isClientClosed.apply(null)) {
+                log.warn().exception(e).log("Failed to schedule sequence updates subscription restart");
+            }
+        }
     }
 }

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -31,8 +31,8 @@ import io.oxia.proto.GetSequenceUpdatesResponse;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import lombok.NonNull;
 
 public class SequenceUpdates implements Closeable {
@@ -46,7 +46,7 @@ public class SequenceUpdates implements Closeable {
     private final RpcProvider rpcProvider;
     private final ShardManager shardManager;
     private final Counter counterSequenceUpdatesReceived;
-    private final Function<Void, Boolean> isClientClosed;
+    private final BooleanSupplier isClientClosed;
     private final ScheduledExecutorService executor;
 
     private boolean closed = false;
@@ -60,7 +60,7 @@ public class SequenceUpdates implements Closeable {
             @NonNull RpcProvider rpcProvider,
             @NonNull ShardManager shardManager,
             @NonNull InstrumentProvider instrumentProvider,
-            Function<Void, Boolean> isClientClosed,
+            @NonNull BooleanSupplier isClientClosed,
             @NonNull ScheduledExecutorService executor) {
         this.key = key;
         this.partitionKey = partitionKey;
@@ -81,7 +81,7 @@ public class SequenceUpdates implements Closeable {
     }
 
     private synchronized void createStream() {
-        if (closed || isClientClosed.apply(null)) {
+        if (closed || isClientClosed.getAsBoolean()) {
             return;
         }
 
@@ -142,7 +142,7 @@ public class SequenceUpdates implements Closeable {
     }
 
     private synchronized void handleError(@NonNull Throwable t) {
-        if (closed || isClientClosed.apply(null)) {
+        if (closed || isClientClosed.getAsBoolean()) {
             return;
         }
         if (Status.fromThrowable(getRootCause(t)).getCode() == Status.Code.DEADLINE_EXCEEDED) {
@@ -154,7 +154,7 @@ public class SequenceUpdates implements Closeable {
     }
 
     private synchronized void handleCompleted() {
-        if (closed || isClientClosed.apply(null)) {
+        if (closed || isClientClosed.getAsBoolean()) {
             return;
         }
         scheduleRestart();

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -91,9 +91,13 @@ public class SequenceUpdates implements Closeable {
 
         var observer =
                 new CancelableStreamObserver<GetSequenceUpdatesResponse>() {
+                    private boolean firstResponse = true;
+
                     @Override
                     protected void handleNext(@NonNull GetSequenceUpdatesResponse value) {
-                        SequenceUpdates.this.handleUpdate(value);
+                        var replayCandidate = firstResponse;
+                        firstResponse = false;
+                        SequenceUpdates.this.handleUpdate(value, replayCandidate);
                     }
 
                     @Override
@@ -123,13 +127,13 @@ public class SequenceUpdates implements Closeable {
         }
     }
 
-    private synchronized void handleUpdate(@NonNull GetSequenceUpdatesResponse value) {
+    private synchronized void handleUpdate(
+            @NonNull GetSequenceUpdatesResponse value, boolean replayCandidate) {
         var highestSequenceKey = value.getHighestSequenceKey();
-        if (lastDeliveredSequenceKey != null
-                && highestSequenceKey.compareTo(lastDeliveredSequenceKey) <= 0) {
-            // Sequence keys use fixed-width numeric suffixes, so lexical order matches sequence
-            // order. A renewal can replay an older snapshot; keep callbacks monotonic by skipping
-            // keys that were already delivered or superseded.
+        if (replayCandidate && highestSequenceKey.equals(lastDeliveredSequenceKey)) {
+            // A renewed subscription starts with the current key. Suppress that initial snapshot
+            // only when it repeats the last callback; later equal or lower keys can be real updates
+            // after sequence records are deleted and recreated.
             return;
         }
         lastDeliveredSequenceKey = highestSequenceKey;

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -15,7 +15,10 @@
  */
 package io.oxia.client;
 
+import static com.google.common.base.Throwables.getRootCause;
+
 import io.github.merlimat.slog.Logger;
+import io.grpc.Status;
 import io.opentelemetry.api.common.Attributes;
 import io.oxia.client.grpc.RpcProvider;
 import io.oxia.client.grpc.observer.CancelableStreamObserver;
@@ -27,6 +30,7 @@ import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.NonNull;
@@ -43,9 +47,11 @@ public class SequenceUpdates implements Closeable {
     private final ShardManager shardManager;
     private final Counter counterSequenceUpdatesReceived;
     private final Function<Void, Boolean> isClientClosed;
+    private final ScheduledExecutorService executor;
 
     private boolean closed = false;
     private CancelableStreamObserver<?> stream;
+    private String lastDeliveredSequenceKey;
 
     SequenceUpdates(
             @NonNull String key,
@@ -54,13 +60,15 @@ public class SequenceUpdates implements Closeable {
             @NonNull RpcProvider rpcProvider,
             @NonNull ShardManager shardManager,
             @NonNull InstrumentProvider instrumentProvider,
-            Function<Void, Boolean> isClientClosed) {
+            Function<Void, Boolean> isClientClosed,
+            @NonNull ScheduledExecutorService executor) {
         this.key = key;
         this.partitionKey = partitionKey;
         this.listener = listener;
         this.rpcProvider = rpcProvider;
         this.shardManager = shardManager;
         this.isClientClosed = isClientClosed;
+        this.executor = executor;
 
         this.counterSequenceUpdatesReceived =
                 instrumentProvider.newCounter(
@@ -73,7 +81,7 @@ public class SequenceUpdates implements Closeable {
     }
 
     private synchronized void createStream() {
-        if (closed) {
+        if (closed || isClientClosed.apply(null)) {
             return;
         }
 
@@ -115,8 +123,17 @@ public class SequenceUpdates implements Closeable {
         }
     }
 
-    private void handleUpdate(@NonNull GetSequenceUpdatesResponse value) {
-        listener.accept(value.getHighestSequenceKey());
+    private synchronized void handleUpdate(@NonNull GetSequenceUpdatesResponse value) {
+        var highestSequenceKey = value.getHighestSequenceKey();
+        if (lastDeliveredSequenceKey != null
+                && highestSequenceKey.compareTo(lastDeliveredSequenceKey) <= 0) {
+            // Sequence keys use fixed-width numeric suffixes, so lexical order matches sequence
+            // order. A renewal can replay an older snapshot; keep callbacks monotonic by skipping
+            // keys that were already delivered or superseded.
+            return;
+        }
+        lastDeliveredSequenceKey = highestSequenceKey;
+        listener.accept(highestSequenceKey);
         counterSequenceUpdatesReceived.increment();
     }
 
@@ -124,11 +141,22 @@ public class SequenceUpdates implements Closeable {
         if (closed || isClientClosed.apply(null)) {
             return;
         }
-        log.warn().exception(t).log("Failure while processing sequence updates");
-        createStream();
+        if (Status.fromThrowable(getRootCause(t)).getCode() == Status.Code.DEADLINE_EXCEEDED) {
+            log.debug("Sequence updates subscription reached its configured maximum age");
+        } else {
+            log.warn().exception(t).log("Failure while processing sequence updates");
+        }
+        scheduleRestart();
     }
 
     private synchronized void handleCompleted() {
-        createStream();
+        if (closed || isClientClosed.apply(null)) {
+            return;
+        }
+        scheduleRestart();
+    }
+
+    private void scheduleRestart() {
+        executor.execute(this::createStream);
     }
 }

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -52,7 +52,6 @@ public class SequenceUpdates implements Closeable {
 
     private boolean closed = false;
     private CancelableStreamObserver<?> stream;
-    private String lastDeliveredSequenceKey;
 
     SequenceUpdates(
             @NonNull String key,
@@ -92,25 +91,10 @@ public class SequenceUpdates implements Closeable {
 
         var observer =
                 new CancelableStreamObserver<GetSequenceUpdatesResponse>() {
-                    private boolean firstResponse = true;
-
                     @Override
                     protected void handleNext(@NonNull GetSequenceUpdatesResponse value) {
-                        var replayCandidate = firstResponse;
-                        firstResponse = false;
-                        var highestSequenceKey = value.getHighestSequenceKey();
-                        synchronized (SequenceUpdates.this) {
-                            if (replayCandidate && highestSequenceKey.equals(lastDeliveredSequenceKey)) {
-                                // A renewed subscription starts with the current key. Suppress that
-                                // initial snapshot only when it repeats the last callback; later
-                                // equal or lower keys can be real updates after sequence records are
-                                // deleted and recreated.
-                                return;
-                            }
-                            lastDeliveredSequenceKey = highestSequenceKey;
-                            listener.accept(highestSequenceKey);
-                            counterSequenceUpdatesReceived.increment();
-                        }
+                        listener.accept(value.getHighestSequenceKey());
+                        counterSequenceUpdatesReceived.increment();
                     }
 
                     @Override

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -98,7 +98,19 @@ public class SequenceUpdates implements Closeable {
                     protected void handleNext(@NonNull GetSequenceUpdatesResponse value) {
                         var replayCandidate = firstResponse;
                         firstResponse = false;
-                        SequenceUpdates.this.handleUpdate(value, replayCandidate);
+                        var highestSequenceKey = value.getHighestSequenceKey();
+                        synchronized (SequenceUpdates.this) {
+                            if (replayCandidate && highestSequenceKey.equals(lastDeliveredSequenceKey)) {
+                                // A renewed subscription starts with the current key. Suppress that
+                                // initial snapshot only when it repeats the last callback; later
+                                // equal or lower keys can be real updates after sequence records are
+                                // deleted and recreated.
+                                return;
+                            }
+                            lastDeliveredSequenceKey = highestSequenceKey;
+                            listener.accept(highestSequenceKey);
+                            counterSequenceUpdatesReceived.increment();
+                        }
                     }
 
                     @Override
@@ -126,20 +138,6 @@ public class SequenceUpdates implements Closeable {
         if (currentStream != null) {
             currentStream.cancel();
         }
-    }
-
-    private synchronized void handleUpdate(
-            @NonNull GetSequenceUpdatesResponse value, boolean replayCandidate) {
-        var highestSequenceKey = value.getHighestSequenceKey();
-        if (replayCandidate && highestSequenceKey.equals(lastDeliveredSequenceKey)) {
-            // A renewed subscription starts with the current key. Suppress that initial snapshot
-            // only when it repeats the last callback; later equal or lower keys can be real updates
-            // after sequence records are deleted and recreated.
-            return;
-        }
-        lastDeliveredSequenceKey = highestSequenceKey;
-        listener.accept(highestSequenceKey);
-        counterSequenceUpdatesReceived.increment();
     }
 
     private synchronized void handleError(@NonNull Throwable t) {

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -82,7 +82,7 @@ public class SequenceUpdates implements Closeable {
     }
 
     private synchronized void createStream() {
-        if (closed || isClientClosed.apply(null)) {
+        if (isClosed()) {
             return;
         }
 
@@ -140,8 +140,12 @@ public class SequenceUpdates implements Closeable {
         }
     }
 
+    private boolean isClosed() {
+        return closed || isClientClosed.apply(null);
+    }
+
     private synchronized void handleError(@NonNull Throwable t) {
-        if (closed || isClientClosed.apply(null)) {
+        if (isClosed()) {
             return;
         }
         if (Status.fromThrowable(getRootCause(t)).getCode() == Status.Code.DEADLINE_EXCEEDED) {
@@ -152,21 +156,21 @@ public class SequenceUpdates implements Closeable {
         try {
             executor.execute(this::createStream);
         } catch (RejectedExecutionException e) {
-            if (!closed && !isClientClosed.apply(null)) {
+            if (!isClosed()) {
                 log.warn().exception(e).log("Failed to schedule sequence updates subscription restart");
             }
         }
     }
 
     private synchronized void handleCompleted() {
-        if (closed || isClientClosed.apply(null)) {
+        if (isClosed()) {
             return;
         }
         log.warn("Stream closed while receiving sequence updates");
         try {
             executor.execute(this::createStream);
         } catch (RejectedExecutionException e) {
-            if (!closed && !isClientClosed.apply(null)) {
+            if (!isClosed()) {
                 log.warn().exception(e).log("Failed to schedule sequence updates subscription restart");
             }
         }

--- a/client/src/main/java/io/oxia/client/SequenceUpdates.java
+++ b/client/src/main/java/io/oxia/client/SequenceUpdates.java
@@ -26,12 +26,14 @@ import io.oxia.client.metrics.Counter;
 import io.oxia.client.metrics.InstrumentProvider;
 import io.oxia.client.metrics.Unit;
 import io.oxia.client.shard.ShardManager;
+import io.oxia.client.util.Backoff;
 import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.NonNull;
@@ -49,6 +51,7 @@ public class SequenceUpdates implements Closeable {
     private final Counter counterSequenceUpdatesReceived;
     private final Function<Void, Boolean> isClientClosed;
     private final ScheduledExecutorService executor;
+    private final Backoff backoff = new Backoff();
 
     private boolean closed = false;
     private CancelableStreamObserver<?> stream;
@@ -93,6 +96,7 @@ public class SequenceUpdates implements Closeable {
                 new CancelableStreamObserver<GetSequenceUpdatesResponse>() {
                     @Override
                     protected void handleNext(@NonNull GetSequenceUpdatesResponse value) {
+                        backoff.reset();
                         listener.accept(value.getHighestSequenceKey());
                         counterSequenceUpdatesReceived.increment();
                     }
@@ -132,13 +136,21 @@ public class SequenceUpdates implements Closeable {
         if (isClosed()) {
             return;
         }
+
+        final long retryDelayMillis;
         if (Status.fromThrowable(getRootCause(t)).getCode() == Status.Code.DEADLINE_EXCEEDED) {
+            backoff.reset();
             log.debug("Sequence updates subscription reached its configured maximum age");
+            retryDelayMillis = 0;
         } else {
-            log.warn().exception(t).log("Failure while processing sequence updates");
+            retryDelayMillis = backoff.nextDelayMillis();
+            log.warn()
+                    .attr("retryInSeconds", retryDelayMillis / 1000.0)
+                    .exception(t)
+                    .log("Failure while processing sequence updates");
         }
         try {
-            executor.execute(this::createStream);
+            executor.schedule(this::createStream, retryDelayMillis, TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
             if (!isClosed()) {
                 log.warn().exception(e).log("Failed to schedule sequence updates subscription restart");
@@ -150,9 +162,12 @@ public class SequenceUpdates implements Closeable {
         if (isClosed()) {
             return;
         }
-        log.warn("Stream closed while receiving sequence updates");
+        long retryDelayMillis = backoff.nextDelayMillis();
+        log.warn()
+                .attr("retryInSeconds", retryDelayMillis / 1000.0)
+                .log("Stream closed while receiving sequence updates");
         try {
-            executor.execute(this::createStream);
+            executor.schedule(this::createStream, retryDelayMillis, TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
             if (!isClosed()) {
                 log.warn().exception(e).log("Failed to schedule sequence updates subscription restart");

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -37,6 +37,7 @@ import io.oxia.proto.ListRequest;
 import io.oxia.proto.ListResponse;
 import io.oxia.proto.NotificationBatch;
 import io.oxia.proto.NotificationsRequest;
+import io.oxia.proto.OxiaClientGrpc;
 import io.oxia.proto.RangeScanRequest;
 import io.oxia.proto.RangeScanResponse;
 import io.oxia.proto.ReadRequest;
@@ -50,6 +51,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongFunction;
@@ -119,10 +121,10 @@ final class GrpcRpcProvider implements RpcProvider {
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
                                 try {
-                                    connectionManager
-                                            .getConnection(clientConfig.serviceAddress())
-                                            .stub()
-                                            .getShardAssignments(request, barrierObserver);
+                                    var stub =
+                                            withSubscriptionMaxAge(
+                                                    connectionManager.getConnection(clientConfig.serviceAddress()).stub());
+                                    stub.getShardAssignments(request, barrierObserver);
                                 } catch (Throwable error) {
                                     barrierFuture.completeExceptionally(OxiaStatusException.from(error));
                                 }
@@ -154,9 +156,10 @@ final class GrpcRpcProvider implements RpcProvider {
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierStreamObserver(guardedObserver, barrierFuture);
                                 try {
-                                    connectionManager
-                                            .getConnection(getLeader(request.getShard(), hint))
-                                            .stub()
+                                    withSubscriptionMaxAge(
+                                                    connectionManager
+                                                            .getConnection(getLeader(request.getShard(), hint))
+                                                            .stub())
                                             .getNotifications(request, barrierObserver);
                                 } catch (Throwable error) {
                                     barrierFuture.completeExceptionally(OxiaStatusException.from(error));
@@ -394,9 +397,10 @@ final class GrpcRpcProvider implements RpcProvider {
                                 final var barrierObserver =
                                         ManagedObservers.toBarrierClientResponseObserver(observer, barrierFuture);
                                 try {
-                                    connectionManager
-                                            .getConnection(getLeader(request.getShard(), hint))
-                                            .stub()
+                                    withSubscriptionMaxAge(
+                                                    connectionManager
+                                                            .getConnection(getLeader(request.getShard(), hint))
+                                                            .stub())
                                             .getSequenceUpdates(request, barrierObserver);
                                 } catch (Throwable error) {
                                     barrierFuture.completeExceptionally(OxiaStatusException.from(error));
@@ -411,6 +415,20 @@ final class GrpcRpcProvider implements RpcProvider {
         } catch (Throwable error) {
             observer.onError(OxiaStatusException.from(error));
         }
+    }
+
+    private OxiaClientGrpc.OxiaClientStub withSubscriptionMaxAge(OxiaClientGrpc.OxiaClientStub stub) {
+        var maxAge = clientConfig.subscriptionMaxAge();
+        if (maxAge == null) {
+            return stub;
+        }
+
+        long maxAgeMillis = maxAge.toMillis();
+        long minAgeMillis = maxAgeMillis / 2;
+        // Match Kubernetes Reflector watches: renew each subscription at a random point in
+        // [maxAge/2, maxAge) to prevent hanging operations without synchronizing clients.
+        long ageMillis = ThreadLocalRandom.current().nextLong(minAgeMillis, maxAgeMillis);
+        return stub.withDeadlineAfter(ageMillis, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -15,7 +15,6 @@
  */
 package io.oxia.client.grpc;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
@@ -424,16 +423,12 @@ final class GrpcRpcProvider implements RpcProvider {
             return stub;
         }
 
-        return stub.withDeadlineAfter(randomizedSubscriptionAgeMillis(maxAge), TimeUnit.MILLISECONDS);
-    }
-
-    @VisibleForTesting
-    static long randomizedSubscriptionAgeMillis(@NonNull Duration maxAge) {
         long maxAgeMillis = maxAge.toMillis();
         long minAgeMillis = maxAgeMillis / 2;
         // Match Kubernetes Reflector watches: renew each subscription at a random point in
         // [maxAge/2, maxAge) to prevent hanging operations without synchronizing clients.
-        return ThreadLocalRandom.current().nextLong(minAgeMillis, maxAgeMillis);
+        long ageMillis = ThreadLocalRandom.current().nextLong(minAgeMillis, maxAgeMillis);
+        return stub.withDeadlineAfter(ageMillis, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
+++ b/client/src/main/java/io/oxia/client/grpc/GrpcRpcProvider.java
@@ -15,6 +15,7 @@
  */
 package io.oxia.client.grpc;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
@@ -423,12 +424,16 @@ final class GrpcRpcProvider implements RpcProvider {
             return stub;
         }
 
+        return stub.withDeadlineAfter(randomizedSubscriptionAgeMillis(maxAge), TimeUnit.MILLISECONDS);
+    }
+
+    @VisibleForTesting
+    static long randomizedSubscriptionAgeMillis(@NonNull Duration maxAge) {
         long maxAgeMillis = maxAge.toMillis();
         long minAgeMillis = maxAgeMillis / 2;
         // Match Kubernetes Reflector watches: renew each subscription at a random point in
         // [maxAge/2, maxAge) to prevent hanging operations without synchronizing clients.
-        long ageMillis = ThreadLocalRandom.current().nextLong(minAgeMillis, maxAgeMillis);
-        return stub.withDeadlineAfter(ageMillis, TimeUnit.MILLISECONDS);
+        return ThreadLocalRandom.current().nextLong(minAgeMillis, maxAgeMillis);
     }
 
     @Override

--- a/client/src/main/java/io/oxia/client/notify/ShardNotificationReceiver.java
+++ b/client/src/main/java/io/oxia/client/notify/ShardNotificationReceiver.java
@@ -15,10 +15,12 @@
  */
 package io.oxia.client.notify;
 
+import static com.google.common.base.Throwables.getRootCause;
 import static io.oxia.client.api.Notification.KeyModified;
 import static lombok.AccessLevel.PACKAGE;
 
 import io.github.merlimat.slog.Logger;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.oxia.client.CompositeConsumer;
 import io.oxia.client.api.Notification;
@@ -83,6 +85,7 @@ public class ShardNotificationReceiver implements Closeable, StreamObserver<Noti
 
     @Override
     public void onNext(NotificationBatch batch) {
+        backoff.reset();
         if (offset.isPresent() && offset.getAsLong() >= batch.getOffset()) {
             // Ignore repeated notifications
             return;
@@ -119,29 +122,39 @@ public class ShardNotificationReceiver implements Closeable, StreamObserver<Noti
             return;
         }
 
+        if (Status.fromThrowable(getRootCause(t)).getCode() == Status.Code.DEADLINE_EXCEEDED) {
+            backoff.reset();
+            log.debug("Notifications subscription reached its configured maximum age");
+            scheduleRestart(0);
+            return;
+        }
+
         long retryDelayMillis = backoff.nextDelayMillis();
         log.warn()
                 .attr("retryInSeconds", retryDelayMillis / 1000.0)
                 .exceptionMessage(t)
                 .log("Error while receiving notifications");
-        notificationManager
-                .getExecutor()
-                .schedule(
-                        () -> {
-                            if (!closed) {
-                                log.info("Retrying getting notifications");
-                                start();
-                            }
-                        },
-                        retryDelayMillis,
-                        TimeUnit.MILLISECONDS);
+        scheduleRestart(retryDelayMillis);
     }
 
     @Override
     public void onCompleted() {
         if (!closed) {
-            start();
+            scheduleRestart(0);
         }
+    }
+
+    private void scheduleRestart(long delayMillis) {
+        notificationManager
+                .getExecutor()
+                .schedule(
+                        () -> {
+                            if (!closed) {
+                                start();
+                            }
+                        },
+                        delayMillis,
+                        TimeUnit.MILLISECONDS);
     }
 
     @RequiredArgsConstructor(access = PACKAGE)

--- a/client/src/main/java/io/oxia/client/shard/ShardManager.java
+++ b/client/src/main/java/io/oxia/client/shard/ShardManager.java
@@ -26,6 +26,7 @@ import static java.util.stream.Collectors.toSet;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.github.merlimat.slog.Logger;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.common.Attributes;
 import io.oxia.client.CompositeConsumer;
@@ -123,15 +124,27 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
                 return;
             }
         }
-        log.warn().exceptionMessage(getRootCause(error)).log("Failed receiving shard assignments");
+        final long retryDelayMillis;
+        if (Status.fromThrowable(getRootCause(error)).getCode() == Status.Code.DEADLINE_EXCEEDED
+                && initialAssignmentsFuture.isDone()) {
+            backoff.reset();
+            log.debug("Shard assignments subscription reached its configured maximum age");
+            retryDelayMillis = 0;
+        } else {
+            log.warn().exceptionMessage(getRootCause(error)).log("Failed receiving shard assignments");
+            retryDelayMillis = backoff.nextDelayMillis();
+        }
+        scheduleRestart(retryDelayMillis);
+    }
+
+    private void scheduleRestart(long delayMillis) {
         asyncExecutor.schedule(
                 () -> {
                     if (!closed) {
-                        log.info("Retry creating stream for shard assignments");
                         start();
                     }
                 },
-                backoff.nextDelayMillis(),
+                delayMillis,
                 TimeUnit.MILLISECONDS);
     }
 
@@ -142,15 +155,7 @@ public class ShardManager implements AutoCloseable, StreamObserver<ShardAssignme
         }
 
         log.warn("Stream closed while receiving shard assignments");
-        asyncExecutor.schedule(
-                () -> {
-                    if (!closed) {
-                        log.info("Retry creating stream for shard assignments after stream closed");
-                        start();
-                    }
-                },
-                backoff.nextDelayMillis(),
-                TimeUnit.MILLISECONDS);
+        scheduleRestart(backoff.nextDelayMillis());
     }
 
     private void updateAssignments(io.oxia.proto.ShardAssignments shardAssignments) {

--- a/client/src/test/java/io/oxia/client/OxiaClientBuilderTest.java
+++ b/client/src/test/java/io/oxia/client/OxiaClientBuilderTest.java
@@ -43,6 +43,29 @@ class OxiaClientBuilderTest {
     }
 
     @Test
+    void subscriptionMaxAge() {
+        assertThatThrownBy(() -> builder.subscriptionMaxAge(ZERO))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.subscriptionMaxAge(Duration.ofMillis(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.subscriptionMaxAge(Duration.ofNanos(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.subscriptionMaxAge(Duration.ofMillis(-1)))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        var timeout = Duration.ofMinutes(1);
+        builder.subscriptionMaxAge(timeout);
+        var impl = (OxiaClientBuilderImpl) builder;
+        assertThat(impl.subscriptionMaxAge).isEqualTo(timeout);
+
+        builder.disableSubscriptionMaxAge();
+        assertThat(impl.subscriptionMaxAge).isNull();
+
+        builder.subscriptionMaxAge(timeout);
+        assertThat(impl.subscriptionMaxAge).isEqualTo(timeout);
+    }
+
+    @Test
     void batchLinger() {
         assertThatThrownBy(() -> builder.batchLinger(ZERO))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -84,6 +107,7 @@ class OxiaClientBuilderTest {
         Properties properties = new Properties();
         properties.setProperty("serviceAddress", "address:5678");
         properties.setProperty("requestTimeout", "1");
+        properties.setProperty("subscriptionMaxAge", "5");
         properties.setProperty("batchLinger", "2");
         properties.setProperty("maxRequestsPerBatch", "3");
         properties.setProperty("sessionTimeout", "4");
@@ -96,6 +120,7 @@ class OxiaClientBuilderTest {
         OxiaClientBuilderImpl impl = (OxiaClientBuilderImpl) builder;
         assertThat(impl.serviceAddress).isEqualTo("address:5678");
         assertThat(impl.requestTimeout).isEqualTo(Duration.ofMillis(1));
+        assertThat(impl.subscriptionMaxAge).isEqualTo(Duration.ofMillis(5));
         assertThat(impl.batchLinger).isEqualTo(Duration.ofMillis(2));
         assertThat(impl.maxRequestsPerBatch).isEqualTo(3);
         assertThat(impl.sessionTimeout).isEqualTo(Duration.ofMillis(4));

--- a/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
+++ b/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
@@ -16,6 +16,7 @@
 package io.oxia.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -60,7 +61,7 @@ class SequenceUpdatesTest {
                             rpcProvider,
                             shardManager,
                             InstrumentProvider.NOOP,
-                            () -> false,
+                            ignored -> false,
                             executor)) {
                 var firstObserver = observerRef.get();
                 var first =
@@ -83,6 +84,9 @@ class SequenceUpdatesTest {
                                 "key-00000000000000000000",
                                 "key-00000000000000000001",
                                 "key-00000000000000000002");
+
+                executor.shutdownNow();
+                assertThatNoException().isThrownBy(renewedObserver::onCompleted);
             }
         } finally {
             executor.shutdownNow();

--- a/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
+++ b/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 
 class SequenceUpdatesTest {
     @Test
-    void ignoresCurrentSequenceKeyAfterSubscriptionRenewal() throws Exception {
+    void onlyIgnoresRepeatedInitialSequenceKeyAfterSubscriptionRenewal() throws Exception {
         var rpcProvider = mock(RpcProvider.class);
         var shardManager = mock(ShardManager.class);
         when(shardManager.getShardForKey(any())).thenReturn(0L);
@@ -70,6 +70,7 @@ class SequenceUpdatesTest {
                 firstObserver.onError(Status.DEADLINE_EXCEEDED.asRuntimeException());
                 await().untilAsserted(() -> assertThat(observerRef.get()).isNotSameAs(firstObserver));
                 var renewedObserver = observerRef.get();
+                renewedObserver.onNext(first);
                 renewedObserver.onNext(
                         new GetSequenceUpdatesResponse().setHighestSequenceKey("key-00000000000000000000"));
                 renewedObserver.onNext(first);
@@ -77,7 +78,11 @@ class SequenceUpdatesTest {
                         new GetSequenceUpdatesResponse().setHighestSequenceKey("key-00000000000000000002"));
 
                 assertThat(delivered)
-                        .containsExactly("key-00000000000000000001", "key-00000000000000000002");
+                        .containsExactly(
+                                "key-00000000000000000001",
+                                "key-00000000000000000000",
+                                "key-00000000000000000001",
+                                "key-00000000000000000002");
             }
         } finally {
             executor.shutdownNow();

--- a/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
+++ b/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
@@ -60,7 +60,7 @@ class SequenceUpdatesTest {
                             rpcProvider,
                             shardManager,
                             InstrumentProvider.NOOP,
-                            ignored -> false,
+                            () -> false,
                             executor)) {
                 var firstObserver = observerRef.get();
                 var first =

--- a/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
+++ b/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.grpc.Status;
+import io.oxia.client.grpc.RpcProvider;
+import io.oxia.client.grpc.observer.CancelableStreamObserver;
+import io.oxia.client.metrics.InstrumentProvider;
+import io.oxia.client.shard.ShardManager;
+import io.oxia.proto.GetSequenceUpdatesRequest;
+import io.oxia.proto.GetSequenceUpdatesResponse;
+import java.util.ArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class SequenceUpdatesTest {
+    @Test
+    void ignoresCurrentSequenceKeyAfterSubscriptionRenewal() throws Exception {
+        var rpcProvider = mock(RpcProvider.class);
+        var shardManager = mock(ShardManager.class);
+        when(shardManager.getShardForKey(any())).thenReturn(0L);
+        var observerRef = new AtomicReference<CancelableStreamObserver<GetSequenceUpdatesResponse>>();
+        doAnswer(
+                        invocation -> {
+                            observerRef.set(invocation.getArgument(1));
+                            return null;
+                        })
+                .when(rpcProvider)
+                .getSequenceUpdates(any(GetSequenceUpdatesRequest.class), any());
+
+        var delivered = new ArrayList<String>();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            try (var updates =
+                    new SequenceUpdates(
+                            "key",
+                            "partition",
+                            delivered::add,
+                            rpcProvider,
+                            shardManager,
+                            InstrumentProvider.NOOP,
+                            ignored -> false,
+                            executor)) {
+                var firstObserver = observerRef.get();
+                var first =
+                        new GetSequenceUpdatesResponse().setHighestSequenceKey("key-00000000000000000001");
+                firstObserver.onNext(first);
+
+                firstObserver.onError(Status.DEADLINE_EXCEEDED.asRuntimeException());
+                await().untilAsserted(() -> assertThat(observerRef.get()).isNotSameAs(firstObserver));
+                var renewedObserver = observerRef.get();
+                renewedObserver.onNext(
+                        new GetSequenceUpdatesResponse().setHighestSequenceKey("key-00000000000000000000"));
+                renewedObserver.onNext(first);
+                renewedObserver.onNext(
+                        new GetSequenceUpdatesResponse().setHighestSequenceKey("key-00000000000000000002"));
+
+                assertThat(delivered)
+                        .containsExactly("key-00000000000000000001", "key-00000000000000000002");
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
+++ b/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -32,10 +34,69 @@ import io.oxia.proto.GetSequenceUpdatesRequest;
 import io.oxia.proto.GetSequenceUpdatesResponse;
 import java.util.ArrayList;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class SequenceUpdatesTest {
+    @Test
+    void backsOffUnexpectedFailuresAndResetsAfterSuccessAndDeadline() throws Exception {
+        var rpcProvider = mock(RpcProvider.class);
+        var shardManager = mock(ShardManager.class);
+        when(shardManager.getShardForKey(any())).thenReturn(0L);
+        var observerRef = new AtomicReference<CancelableStreamObserver<GetSequenceUpdatesResponse>>();
+        doAnswer(
+                        invocation -> {
+                            observerRef.set(invocation.getArgument(1));
+                            return null;
+                        })
+                .when(rpcProvider)
+                .getSequenceUpdates(any(GetSequenceUpdatesRequest.class), any());
+
+        var scheduledTasks = new ArrayList<Runnable>();
+        var retryDelays = new ArrayList<Long>();
+        var executor = mock(ScheduledExecutorService.class);
+        when(executor.schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS)))
+                .thenAnswer(
+                        invocation -> {
+                            scheduledTasks.add(invocation.getArgument(0));
+                            retryDelays.add(invocation.getArgument(1));
+                            return null;
+                        });
+
+        try (var updates =
+                new SequenceUpdates(
+                        "key",
+                        "partition",
+                        ignored -> {},
+                        rpcProvider,
+                        shardManager,
+                        InstrumentProvider.NOOP,
+                        ignored -> false,
+                        executor)) {
+            observerRef.get().onError(Status.UNAVAILABLE.asRuntimeException());
+            assertThat(retryDelays.get(0)).isBetween(100L, 119L);
+
+            scheduledTasks.remove(0).run();
+            observerRef.get().onError(Status.UNAVAILABLE.asRuntimeException());
+            assertThat(retryDelays.get(1)).isBetween(200L, 239L);
+
+            scheduledTasks.remove(0).run();
+            observerRef.get().onNext(new GetSequenceUpdatesResponse());
+            observerRef.get().onError(Status.UNAVAILABLE.asRuntimeException());
+            assertThat(retryDelays.get(2)).isBetween(100L, 119L);
+
+            scheduledTasks.remove(0).run();
+            observerRef.get().onError(Status.DEADLINE_EXCEEDED.asRuntimeException());
+            assertThat(retryDelays.get(3)).isZero();
+
+            scheduledTasks.remove(0).run();
+            observerRef.get().onError(Status.UNAVAILABLE.asRuntimeException());
+            assertThat(retryDelays.get(4)).isBetween(100L, 119L);
+        }
+    }
+
     @Test
     void deliversAllSequenceUpdatesAcrossSubscriptionRenewal() throws Exception {
         var rpcProvider = mock(RpcProvider.class);

--- a/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
+++ b/client/src/test/java/io/oxia/client/SequenceUpdatesTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 class SequenceUpdatesTest {
     @Test
-    void onlyIgnoresRepeatedInitialSequenceKeyAfterSubscriptionRenewal() throws Exception {
+    void deliversAllSequenceUpdatesAcrossSubscriptionRenewal() throws Exception {
         var rpcProvider = mock(RpcProvider.class);
         var shardManager = mock(ShardManager.class);
         when(shardManager.getShardForKey(any())).thenReturn(0L);
@@ -80,6 +80,7 @@ class SequenceUpdatesTest {
 
                 assertThat(delivered)
                         .containsExactly(
+                                "key-00000000000000000001",
                                 "key-00000000000000000001",
                                 "key-00000000000000000000",
                                 "key-00000000000000000001",

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -52,6 +52,7 @@ import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
 import io.oxia.proto.WriteResponse;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -63,6 +64,17 @@ import lombok.NonNull;
 import org.junit.jupiter.api.Test;
 
 class GrpcRpcProviderTest {
+    @Test
+    void subscriptionAgeIsRandomizedBetweenHalfAndMaximum() {
+        var ages = new HashSet<Long>();
+
+        for (int i = 0; i < 1_000; i++) {
+            ages.add(GrpcRpcProvider.randomizedSubscriptionAgeMillis(Duration.ofMillis(200)));
+        }
+
+        assertThat(ages).hasSizeGreaterThan(1).allMatch(age -> age >= 100 && age < 200);
+    }
+
     @Test
     void keepAliveRetriesWithLeaderHint() throws Exception {
         var leaderServerRequests = new AtomicReference<SessionHeartbeat>();

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
 import org.junit.jupiter.api.Test;
@@ -915,6 +916,237 @@ class GrpcRpcProviderTest {
             releaseStream.countDown();
             assertThat(secondMessage.await(5, TimeUnit.SECONDS)).isTrue();
             assertThat(error.get()).isNull();
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void longLivedSubscriptionsUseRandomizedDeadline() throws Exception {
+        var assignmentsDeadlineMillis = new AtomicLong(-1);
+        var notificationsDeadlineMillis = new AtomicLong(-1);
+        var sequenceUpdatesDeadlineMillis = new AtomicLong(-1);
+        Server server =
+                ServerBuilder.forPort(0)
+                        .directExecutor()
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getShardAssignments(
+                                            ShardAssignmentsRequest request,
+                                            StreamObserver<ShardAssignments> responseObserver) {
+                                        var deadline = Context.current().getDeadline();
+                                        if (deadline != null) {
+                                            assignmentsDeadlineMillis.set(deadline.timeRemaining(TimeUnit.MILLISECONDS));
+                                        }
+                                        responseObserver.onNext(new ShardAssignments());
+                                    }
+
+                                    @Override
+                                    public void getNotifications(
+                                            NotificationsRequest request,
+                                            StreamObserver<NotificationBatch> responseObserver) {
+                                        var deadline = Context.current().getDeadline();
+                                        if (deadline != null) {
+                                            notificationsDeadlineMillis.set(
+                                                    deadline.timeRemaining(TimeUnit.MILLISECONDS));
+                                        }
+                                        responseObserver.onNext(new NotificationBatch());
+                                    }
+
+                                    @Override
+                                    public void getSequenceUpdates(
+                                            GetSequenceUpdatesRequest request,
+                                            StreamObserver<GetSequenceUpdatesResponse> responseObserver) {
+                                        var deadline = Context.current().getDeadline();
+                                        if (deadline != null) {
+                                            sequenceUpdatesDeadlineMillis.set(
+                                                    deadline.timeRemaining(TimeUnit.MILLISECONDS));
+                                        }
+                                        responseObserver.onNext(new GetSequenceUpdatesResponse());
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl)
+                                OxiaClientBuilder.create(address)
+                                        .requestTimeout(Duration.ofSeconds(5))
+                                        .subscriptionMaxAge(Duration.ofMillis(200)))
+                        .getClientConfig();
+        var received = new CountDownLatch(3);
+        var terminated = new CountDownLatch(3);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.getShardAssignments(
+                    new ShardAssignmentsRequest(),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ShardAssignments value) {
+                            received.countDown();
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminated.countDown();
+                        }
+                    });
+            provider.getNotifications(
+                    new NotificationsRequest().setShard(1),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(NotificationBatch value) {
+                            received.countDown();
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminated.countDown();
+                        }
+                    });
+            provider.getSequenceUpdates(
+                    new GetSequenceUpdatesRequest().setShard(1),
+                    new CancelableStreamObserver<>() {
+                        @Override
+                        protected void handleNext(GetSequenceUpdatesResponse value) {
+                            received.countDown();
+                        }
+
+                        @Override
+                        protected void handleError(Throwable t) {
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        protected void handleComplete() {
+                            terminated.countDown();
+                        }
+                    });
+
+            assertThat(received.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(terminated.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(assignmentsDeadlineMillis.get()).isBetween(1L, 200L);
+            assertThat(notificationsDeadlineMillis.get()).isBetween(1L, 200L);
+            assertThat(sequenceUpdatesDeadlineMillis.get()).isBetween(1L, 200L);
+        } finally {
+            executor.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void longLivedSubscriptionsCanDisableDeadline() throws Exception {
+        var assignmentsDeadline = new AtomicReference<io.grpc.Deadline>();
+        var notificationsDeadline = new AtomicReference<io.grpc.Deadline>();
+        var sequenceUpdatesDeadline = new AtomicReference<io.grpc.Deadline>();
+        Server server =
+                ServerBuilder.forPort(0)
+                        .directExecutor()
+                        .addService(
+                                new OxiaClientGrpc.OxiaClientImplBase() {
+                                    @Override
+                                    public void getShardAssignments(
+                                            ShardAssignmentsRequest request,
+                                            StreamObserver<ShardAssignments> responseObserver) {
+                                        assignmentsDeadline.set(Context.current().getDeadline());
+                                        responseObserver.onNext(new ShardAssignments());
+                                        responseObserver.onCompleted();
+                                    }
+
+                                    @Override
+                                    public void getNotifications(
+                                            NotificationsRequest request,
+                                            StreamObserver<NotificationBatch> responseObserver) {
+                                        notificationsDeadline.set(Context.current().getDeadline());
+                                        responseObserver.onNext(new NotificationBatch());
+                                        responseObserver.onCompleted();
+                                    }
+
+                                    @Override
+                                    public void getSequenceUpdates(
+                                            GetSequenceUpdatesRequest request,
+                                            StreamObserver<GetSequenceUpdatesResponse> responseObserver) {
+                                        sequenceUpdatesDeadline.set(Context.current().getDeadline());
+                                        responseObserver.onNext(new GetSequenceUpdatesResponse());
+                                        responseObserver.onCompleted();
+                                    }
+                                })
+                        .build()
+                        .start();
+        var address = "localhost:" + server.getPort();
+        var executor = Executors.newSingleThreadScheduledExecutor();
+        var config =
+                ((OxiaClientBuilderImpl) OxiaClientBuilder.create(address).disableSubscriptionMaxAge())
+                        .getClientConfig();
+        var completed = new CountDownLatch(3);
+
+        try (var provider = new GrpcRpcProvider(config, executor, shardId -> address)) {
+            provider.getShardAssignments(
+                    new ShardAssignmentsRequest(),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(ShardAssignments value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            completed.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            completed.countDown();
+                        }
+                    });
+            provider.getNotifications(
+                    new NotificationsRequest().setShard(1),
+                    new StreamObserver<>() {
+                        @Override
+                        public void onNext(NotificationBatch value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            completed.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            completed.countDown();
+                        }
+                    });
+            provider.getSequenceUpdates(
+                    new GetSequenceUpdatesRequest().setShard(1),
+                    new CancelableStreamObserver<>() {
+                        @Override
+                        protected void handleNext(GetSequenceUpdatesResponse value) {}
+
+                        @Override
+                        protected void handleError(Throwable t) {
+                            completed.countDown();
+                        }
+
+                        @Override
+                        protected void handleComplete() {
+                            completed.countDown();
+                        }
+                    });
+
+            assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(assignmentsDeadline.get()).isNull();
+            assertThat(notificationsDeadline.get()).isNull();
+            assertThat(sequenceUpdatesDeadline.get()).isNull();
         } finally {
             executor.shutdownNow();
             server.shutdownNow();

--- a/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/GrpcRpcProviderTest.java
@@ -52,7 +52,6 @@ import io.oxia.proto.ShardAssignments;
 import io.oxia.proto.ShardAssignmentsRequest;
 import io.oxia.proto.WriteResponse;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -64,17 +63,6 @@ import lombok.NonNull;
 import org.junit.jupiter.api.Test;
 
 class GrpcRpcProviderTest {
-    @Test
-    void subscriptionAgeIsRandomizedBetweenHalfAndMaximum() {
-        var ages = new HashSet<Long>();
-
-        for (int i = 0; i < 1_000; i++) {
-            ages.add(GrpcRpcProvider.randomizedSubscriptionAgeMillis(Duration.ofMillis(200)));
-        }
-
-        assertThat(ages).hasSizeGreaterThan(1).allMatch(age -> age >= 100 && age < 200);
-    }
-
     @Test
     void keepAliveRetriesWithLeaderHint() throws Exception {
         var leaderServerRequests = new AtomicReference<SessionHeartbeat>();

--- a/client/src/test/java/io/oxia/client/notify/ShardNotificationReceiverTest.java
+++ b/client/src/test/java/io/oxia/client/notify/ShardNotificationReceiverTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import lombok.Cleanup;
 import org.junit.jupiter.api.AfterEach;
@@ -69,22 +70,28 @@ class ShardNotificationReceiverTest {
                 @Override
                 public void getNotifications(
                         NotificationsRequest request, StreamObserver<NotificationBatch> responseObserver) {
-                    requests.incrementAndGet();
-                    NotificationWrapper nw = responses.poll();
-                    if (nw != null) {
+                    if (requests.incrementAndGet() == 2 && request.hasStartOffsetExclusive()) {
+                        resumedFromOffset.set(request.getStartOffsetExclusive());
+                    }
+                    while (true) {
+                        NotificationWrapper nw = responses.poll();
+                        if (nw == null) {
+                            return;
+                        }
                         if (nw.ex != null) {
                             responseObserver.onError(nw.ex);
-                        } else {
-                            responseObserver.onNext(nw.notifications);
-
-                            if (nw.endOfStream) {
-                                responseObserver.onCompleted();
-                            }
+                            return;
+                        }
+                        responseObserver.onNext(nw.notifications);
+                        if (nw.endOfStream) {
+                            responseObserver.onCompleted();
+                            return;
                         }
                     }
                 }
             };
     AtomicInteger requests = new AtomicInteger();
+    AtomicLong resumedFromOffset = new AtomicLong(-1);
 
     String serverName = InProcessServerBuilder.generateName();
     Server server;
@@ -98,6 +105,7 @@ class ShardNotificationReceiverTest {
     @BeforeEach
     void beforeEach() throws Exception {
         requests.set(0);
+        resumedFromOffset.set(-1);
         responses.clear();
         server =
                 InProcessServerBuilder.forName(serverName)
@@ -224,6 +232,39 @@ class ShardNotificationReceiverTest {
             await().untilAsserted(() -> verify(notificationCallback).accept(new KeyCreated("key1", 1L)));
         }
         assertThat(requests).hasValue(2);
+    }
+
+    @Test
+    void renewalResumesAfterLastReceivedOffset() {
+        @Cleanup("shutdownNow")
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        when(notificationManager.getExecutor()).thenReturn(executorService);
+        when(notificationManager.getCounterNotificationsReceived()).thenReturn(mock(Counter.class));
+        when(notificationManager.getCounterNotificationsBatchesReceived())
+                .thenReturn(mock(Counter.class));
+
+        var firstBatch = newNotificationBatch("key1", created(1L)).setOffset(7);
+        var secondBatch = newNotificationBatch("key2", created(2L)).setOffset(8);
+        assertThat(responses.offer(new NotificationWrapper(firstBatch, null, false))).isTrue();
+        assertThat(
+                        responses.offer(
+                                new NotificationWrapper(
+                                        null, Status.DEADLINE_EXCEEDED.asRuntimeException(), false)))
+                .isTrue();
+        assertThat(responses.offer(new NotificationWrapper(secondBatch, null, false))).isTrue();
+
+        try (var notificationReceiver =
+                new ShardNotificationReceiver(
+                        rpcProvider,
+                        shardId,
+                        notificationCallback,
+                        notificationManager,
+                        OptionalLong.empty())) {
+            await().untilAsserted(() -> verify(notificationCallback).accept(new KeyCreated("key2", 2L)));
+        }
+
+        assertThat(requests).hasValue(2);
+        assertThat(resumedFromOffset).hasValue(7);
     }
 
     @Test

--- a/client/src/test/java/io/oxia/client/notify/ShardNotificationReceiverTest.java
+++ b/client/src/test/java/io/oxia/client/notify/ShardNotificationReceiverTest.java
@@ -197,7 +197,40 @@ class ShardNotificationReceiverTest {
     }
 
     @Test
+    void renewsImmediatelyAtConfiguredMaximumAge() {
+        @Cleanup("shutdownNow")
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        when(notificationManager.getExecutor()).thenReturn(executorService);
+        when(notificationManager.getCounterNotificationsReceived()).thenReturn(mock(Counter.class));
+        when(notificationManager.getCounterNotificationsBatchesReceived())
+                .thenReturn(mock(Counter.class));
+
+        assertThat(
+                        responses.offer(
+                                new NotificationWrapper(
+                                        null, Status.DEADLINE_EXCEEDED.asRuntimeException(), false)))
+                .isTrue();
+        assertThat(
+                        responses.offer(
+                                new NotificationWrapper(newNotificationBatch("key1", created(1L)), null, false)))
+                .isTrue();
+        try (var notificationReceiver =
+                new ShardNotificationReceiver(
+                        rpcProvider,
+                        shardId,
+                        notificationCallback,
+                        notificationManager,
+                        OptionalLong.empty())) {
+            await().untilAsserted(() -> verify(notificationCallback).accept(new KeyCreated("key1", 1L)));
+        }
+        assertThat(requests).hasValue(2);
+    }
+
+    @Test
     public void recoveryFromEndOfStream() throws Exception {
+        @Cleanup("shutdownNow")
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        when(notificationManager.getExecutor()).thenReturn(executorService);
         when(notificationManager.getCounterNotificationsReceived()).thenReturn(mock(Counter.class));
         when(notificationManager.getCounterNotificationsBatchesReceived())
                 .thenReturn(mock(Counter.class));

--- a/client/src/test/java/io/oxia/client/shard/ShardManagerGrpcTest.java
+++ b/client/src/test/java/io/oxia/client/shard/ShardManagerGrpcTest.java
@@ -230,6 +230,26 @@ class ShardManagerGrpcTest {
     }
 
     @Test
+    void renewsAfterConfiguredMaximumAge() {
+        var assignments = new ShardAssignments();
+        assignments.putNamespaces(DefaultNamespace).addAssignment().copyFrom(assignment(0, 0, 3));
+        assertThat(responses.offer(new AssignmentWrapper(assignments, null, false))).isTrue();
+        assertThat(
+                        responses.offer(
+                                new AssignmentWrapper(null, Status.DEADLINE_EXCEEDED.asRuntimeException(), false)))
+                .isTrue();
+        assertThat(responses.offer(new AssignmentWrapper(assignments, null, false))).isTrue();
+
+        try (var shardManager =
+                new ShardManager(asyncExecutor, rpcProvider, InstrumentProvider.NOOP, DefaultNamespace)) {
+            assertThat(shardManager.start()).succeedsWithin(Duration.ofSeconds(1));
+            await().untilAsserted(() -> assertThat(requests).hasValue(2));
+            assertThat(shardManager.allShardIds()).containsExactlyInAnyOrder(0L);
+            assertThat(shardManager.leader(0)).isEqualTo("leader0");
+        }
+    }
+
+    @Test
     public void recoveryFromEndOfStream() {
         assertThat(responses.offer(new AssignmentWrapper(null, null, true))).isTrue();
         var assignments = new ShardAssignments();


### PR DESCRIPTION
## Motivation

Shard assignments, notifications, and sequence updates are long-lived client operations. When traffic passes through Istio or Envoy, the proxy can lose its upstream connection while keeping its downstream HTTP/2 connection to the client open. Transport keepalive can still succeed against the proxy, leaving the client with a subscription that appears healthy but no longer receives updates. Request-establishment safeguards do not detect a stream that stalls after its first response.

Give each subscription a bounded, randomized lifetime and recreate it from its latest state. This makes recovery independent of whether an intermediary propagates the upstream disconnect, while jitter spreads renewals across clients. The approach follows the bounded-watch pattern used by the [Kubernetes `client-go` Reflector](https://github.com/kubernetes/client-go/blob/master/tools/cache/reflector.go).

## Modifications

- Add `subscriptionMaxAge(Duration)` with a default maximum of 10 minutes. Each subscription receives a client-local gRPC deadline selected from `[maxAge / 2, maxAge)`, giving the default range of 5–10 minutes.
- Add `disableSubscriptionMaxAge()` for deployments that explicitly require unbounded subscriptions.
- Apply bounded lifetimes to shard assignments, notifications, and sequence updates.
- Preserve operation state across renewal: shard assignments restart from a complete snapshot, notifications resume after the last received offset, and sequence updates report the current highest key using the existing delivery semantics, including possible replay of the latest key.
- Treat maximum-age expiry as expected: log it at debug level, reset failure backoff, and renew immediately on the client scheduler rather than from the gRPC callback thread.
- Apply randomized exponential backoff to unexpected sequence-update failures and completed streams, resetting it after a successful response.
- Preserve the existing RPC retry behavior, contain executor-rejection races, and retain warning logs for unexpected failures and end-of-stream.
- Document the new configuration and clarify that these client subscriptions are not inactivity timeouts or exposed transport streams.

## Testing

- `./gradlew --no-parallel :client:test --tests '*Test' spotlessCheck :client-api:javadoc`
- Added coverage for builder validation, randomized deadlines, and disabling the maximum age across all three subscription types.
- Added coverage for immediate renewal, assignment snapshots, notification offset resumption, sequence-key replay, sequence restart backoff and reset, and rejected renewal scheduling.
