### PR TITLE
fix: support leader lookup with Oxia 0.16.x

### DIFF
--- a/client/src/main/java/io/oxia/client/grpc/LegacyLeaderHintStatusDecoder.java
+++ b/client/src/main/java/io/oxia/client/grpc/LegacyLeaderHintStatusDecoder.java
@@ -32,6 +32,10 @@ final class LegacyLeaderHintStatusDecoder implements OxiaStatusDecoder {
 
     @Override
     public OxiaStatusException decode(Throwable cause) {
+        if (Status.fromThrowable(cause).getCode() != Status.Code.UNKNOWN) {
+            return new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);
+        }
+
         final var trailers = Status.trailersFromThrowable(cause);
         final var grpcStatus = trailers == null ? null : trailers.get(GRPC_STATUS_DETAILS_KEY);
         if (grpcStatus == null || grpcStatus.getCode() != 106) {

--- a/client/src/main/java/io/oxia/client/grpc/LegacyLeaderHintStatusDecoder.java
+++ b/client/src/main/java/io/oxia/client/grpc/LegacyLeaderHintStatusDecoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import static io.oxia.client.grpc.OxiaStatusCode.NODE_IS_NOT_LEADER;
+import static io.oxia.client.grpc.OxiaStatusCode.UNKNOWN;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.protobuf.ProtoUtils;
+import io.oxia.proto.LeaderHint;
+import java.util.Map;
+
+final class LegacyLeaderHintStatusDecoder implements OxiaStatusDecoder {
+    private static final Metadata.Key<com.google.rpc.Status> GRPC_STATUS_DETAILS_KEY =
+            Metadata.Key.of(
+                    "grpc-status-details-bin",
+                    ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance()));
+
+    @Override
+    public OxiaStatusException decode(Throwable cause) {
+        final var trailers = Status.trailersFromThrowable(cause);
+        final var grpcStatus = trailers == null ? null : trailers.get(GRPC_STATUS_DETAILS_KEY);
+        if (grpcStatus == null || grpcStatus.getCode() != 106) {
+            return new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);
+        }
+
+        for (final var detail : grpcStatus.getDetailsList()) {
+            if (!"type.googleapis.com/io.oxia.proto.v1.LeaderHint".equals(detail.getTypeUrl())) {
+                continue;
+            }
+            try {
+                final var hint = new LeaderHint();
+                hint.parseFrom(detail.getValue().toByteArray());
+                final var metadata =
+                        Map.of(
+                                "shard", Long.toString(hint.getShard()),
+                                "leader", hint.getLeaderAddress());
+                final var message =
+                        grpcStatus.getMessage().isEmpty()
+                                ? "oxia status " + NODE_IS_NOT_LEADER
+                                : grpcStatus.getMessage();
+                return new OxiaStatusException(NODE_IS_NOT_LEADER, metadata, message, cause);
+            } catch (RuntimeException ignored) {
+                // Ignore malformed hint details
+            }
+            break;
+        }
+        return new OxiaStatusException(UNKNOWN, Map.of(), grpcStatus.getMessage(), cause);
+    }
+}

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStatusDecoder.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStatusDecoder.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+interface OxiaStatusDecoder {
+    OxiaStatusException decode(Throwable cause);
+}

--- a/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
+++ b/client/src/main/java/io/oxia/client/grpc/OxiaStatusException.java
@@ -20,12 +20,10 @@ import static io.oxia.client.grpc.OxiaStatusCode.SHARD_NOT_FOUND;
 import static io.oxia.client.grpc.OxiaStatusCode.TIMEOUT;
 import static io.oxia.client.grpc.OxiaStatusCode.UNKNOWN;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.rpc.ErrorInfo;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
-import io.grpc.protobuf.StatusProto;
 import io.oxia.client.util.CompletableFutures;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
@@ -34,6 +32,10 @@ import lombok.NonNull;
 
 /** Exception carrying an Oxia status code translated from a GRPC status error. */
 public class OxiaStatusException extends RuntimeException {
+    // Keep the legacy decoder first because StatusProto rejects Oxia 0.16.x custom status code 106.
+    private static final List<OxiaStatusDecoder> STATUS_DECODERS =
+            List.of(new LegacyLeaderHintStatusDecoder(), new StandardGrpcStatusDecoder());
+
     @Getter private final @NonNull OxiaStatusCode statusCode;
     @Getter private final @NonNull Map<String, String> metadata;
 
@@ -105,80 +107,18 @@ public class OxiaStatusException extends RuntimeException {
                 return new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);
             }
 
-            final var grpcStatus = StatusProto.fromThrowable(cause);
-            if (grpcStatus == null) {
-                return new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);
+            OxiaStatusException decodedError = null;
+            for (final var decoder : STATUS_DECODERS) {
+                decodedError = decoder.decode(cause);
+                if (decodedError.getStatusCode() != UNKNOWN) {
+                    return decodedError;
+                }
             }
-            return fromGrpcStatus(grpcStatus, cause);
+            return decodedError != null
+                    ? decodedError
+                    : new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);
         } catch (RuntimeException e) {
             return new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);
         }
-    }
-
-    private static OxiaStatusException fromGrpcStatus(
-            com.google.rpc.Status grpcStatus, Throwable cause) {
-        OxiaStatusCode statusCode = UNKNOWN;
-        Map<String, String> metadata = Map.of();
-
-        // parse from the error info
-        for (var detail : grpcStatus.getDetailsList()) {
-            if (!detail.is(ErrorInfo.class)) {
-                continue;
-            }
-            try {
-                var info = detail.unpack(ErrorInfo.class);
-                if (!"oxia.io".equals(info.getDomain())) {
-                    continue;
-                }
-                try {
-                    statusCode = OxiaStatusCode.valueOf(info.getReason());
-                } catch (IllegalArgumentException e) {
-                    statusCode = UNKNOWN;
-                }
-                metadata = info.getMetadataMap();
-                break;
-            } catch (InvalidProtocolBufferException ignored) {
-            }
-        }
-        // parse from the grpc standard code
-        if (statusCode == UNKNOWN) {
-            statusCode =
-                    switch (io.grpc.Status.fromCodeValue(grpcStatus.getCode()).getCode()) {
-                        case UNAVAILABLE -> OxiaStatusCode.RESOURCE_UNAVAILABLE;
-                        case ABORTED -> OxiaStatusCode.ABORTED;
-                        default -> UNKNOWN;
-                    };
-        }
-        // parse by the error messages
-        if (statusCode == UNKNOWN) {
-            statusCode =
-                    switch (grpcStatus.getMessage()) {
-                        case "oxia: server not initialized yet" -> OxiaStatusCode.NOT_INITIALIZED;
-                        case "oxia: operation was cancelled",
-                                "oxia: resource is already closed",
-                                "oxia: leader is already connected" ->
-                                OxiaStatusCode.ABORTED;
-                        case "oxia: invalid term" -> OxiaStatusCode.INVALID_TERM;
-                        case "oxia: invalid status" -> OxiaStatusCode.INVALID_STATUS;
-                        case "oxia: session not found" -> OxiaStatusCode.SESSION_NOT_FOUND;
-                        case "oxia: invalid session timeout" -> OxiaStatusCode.INVALID_SESSION_TIMEOUT;
-                        case "oxia: namespace not found" -> OxiaStatusCode.NAMESPACE_NOT_FOUND;
-                        case "oxia: notifications not enabled on namespace" ->
-                                OxiaStatusCode.NOTIFICATIONS_NOT_ENABLED;
-                        case "oxia: node is not a member" -> OxiaStatusCode.NODE_IS_NOT_MEMBER;
-                        default -> {
-                            if (grpcStatus.getMessage().startsWith("node is not leader for shard ")) {
-                                yield OxiaStatusCode.NODE_IS_NOT_LEADER;
-                            }
-                            if (grpcStatus.getMessage().startsWith("node is not follower for shard ")) {
-                                yield OxiaStatusCode.ABORTED;
-                            }
-                            yield UNKNOWN;
-                        }
-                    };
-        }
-        final var message =
-                grpcStatus.getMessage().isEmpty() ? "oxia status " + statusCode : grpcStatus.getMessage();
-        return new OxiaStatusException(statusCode, metadata, message, cause);
     }
 }

--- a/client/src/main/java/io/oxia/client/grpc/StandardGrpcStatusDecoder.java
+++ b/client/src/main/java/io/oxia/client/grpc/StandardGrpcStatusDecoder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2026 The Oxia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.oxia.client.grpc;
+
+import static io.oxia.client.grpc.OxiaStatusCode.UNKNOWN;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.rpc.ErrorInfo;
+import io.grpc.protobuf.StatusProto;
+import java.util.Map;
+
+final class StandardGrpcStatusDecoder implements OxiaStatusDecoder {
+    @Override
+    public OxiaStatusException decode(Throwable cause) {
+        final var grpcStatus = StatusProto.fromThrowable(cause);
+        if (grpcStatus == null) {
+            return new OxiaStatusException(UNKNOWN, Map.of(), cause.getMessage(), cause);
+        }
+
+        var statusCode = UNKNOWN;
+        Map<String, String> metadata = Map.of();
+        for (final var detail : grpcStatus.getDetailsList()) {
+            if (!detail.is(ErrorInfo.class)) {
+                continue;
+            }
+            try {
+                final var info = detail.unpack(ErrorInfo.class);
+                if (!"oxia.io".equals(info.getDomain())) {
+                    continue;
+                }
+                try {
+                    statusCode = OxiaStatusCode.valueOf(info.getReason());
+                } catch (IllegalArgumentException e) {
+                    statusCode = UNKNOWN;
+                }
+                metadata = info.getMetadataMap();
+                break;
+            } catch (InvalidProtocolBufferException ignored) {
+            }
+        }
+        if (statusCode == UNKNOWN) {
+            statusCode =
+                    switch (io.grpc.Status.fromCodeValue(grpcStatus.getCode()).getCode()) {
+                        case UNAVAILABLE -> OxiaStatusCode.RESOURCE_UNAVAILABLE;
+                        case ABORTED -> OxiaStatusCode.ABORTED;
+                        default -> UNKNOWN;
+                    };
+        }
+        if (statusCode == UNKNOWN) {
+            statusCode =
+                    switch (grpcStatus.getMessage()) {
+                        case "oxia: server not initialized yet" -> OxiaStatusCode.NOT_INITIALIZED;
+                        case "oxia: operation was cancelled",
+                                "oxia: resource is already closed",
+                                "oxia: leader is already connected" ->
+                                OxiaStatusCode.ABORTED;
+                        case "oxia: invalid term" -> OxiaStatusCode.INVALID_TERM;
+                        case "oxia: invalid status" -> OxiaStatusCode.INVALID_STATUS;
+                        case "oxia: session not found" -> OxiaStatusCode.SESSION_NOT_FOUND;
+                        case "oxia: invalid session timeout" -> OxiaStatusCode.INVALID_SESSION_TIMEOUT;
+                        case "oxia: namespace not found" -> OxiaStatusCode.NAMESPACE_NOT_FOUND;
+                        case "oxia: notifications not enabled on namespace" ->
+                                OxiaStatusCode.NOTIFICATIONS_NOT_ENABLED;
+                        case "oxia: node is not a member" -> OxiaStatusCode.NODE_IS_NOT_MEMBER;
+                        default -> {
+                            if (grpcStatus.getMessage().startsWith("node is not leader for shard ")) {
+                                yield OxiaStatusCode.NODE_IS_NOT_LEADER;
+                            }
+                            if (grpcStatus.getMessage().startsWith("node is not follower for shard ")) {
+                                yield OxiaStatusCode.ABORTED;
+                            }
+                            yield UNKNOWN;
+                        }
+                    };
+        }
+        final var message =
+                grpcStatus.getMessage().isEmpty() ? "oxia status " + statusCode : grpcStatus.getMessage();
+        return new OxiaStatusException(statusCode, metadata, message, cause);
+    }
+}

--- a/client/src/main/proto/io/streamnative/oxia/client.proto
+++ b/client/src/main/proto/io/streamnative/oxia/client.proto
@@ -127,6 +127,18 @@ message ShardAssignmentsRequest {
 }
 
 /**
+ * The hint about the current leader of a shard, returned as a detail of
+ * `node is not leader` errors by Oxia servers before 0.17.0.
+ */
+message LeaderHint {
+  // The shard id
+  int64 shard = 1;
+
+  // The current shard leader, e.g. `host:port`
+  string leader_address = 2;
+}
+
+/**
  * The response to a shard assignments request.
  */
 message ShardAssignments {

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
@@ -101,6 +101,36 @@ class OxiaStatusExceptionTest {
     }
 
     @Test
+    void rejectsLegacy016LeaderHintForMismatchedOuterStatus() {
+        final var leaderHint = new LeaderHint().setShard(1).setLeaderAddress("server-1:6648");
+        final var grpcStatus =
+                com.google.rpc.Status.newBuilder()
+                        .setCode(106)
+                        .setMessage("node is not leader for shard 1")
+                        .addDetails(
+                                Any.newBuilder()
+                                        .setTypeUrl("type.googleapis.com/io.oxia.proto.v1.LeaderHint")
+                                        .setValue(ByteString.copyFrom(leaderHint.toByteArray())))
+                        .build();
+        final var trailers = new Metadata();
+        trailers.put(
+                Metadata.Key.of(
+                        "grpc-status-details-bin",
+                        ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance())),
+                grpcStatus);
+
+        final var error =
+                OxiaStatusException.from(
+                        Status.PERMISSION_DENIED
+                                .withDescription("outer permission denied")
+                                .asRuntimeException(trailers));
+
+        assertThat(error.getStatusCode()).isEqualTo(OxiaStatusCode.UNKNOWN);
+        assertThat(error).hasMessageContaining("outer permission denied");
+        assertThat(error.isRetryable()).isFalse();
+    }
+
+    @Test
     void convertsLegacy0163Messages() {
         Map.ofEntries(
                         entry("oxia: server not initialized yet", OxiaStatusCode.NOT_INITIALIZED),

--- a/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
+++ b/client/src/test/java/io/oxia/client/grpc/OxiaStatusExceptionTest.java
@@ -19,11 +19,13 @@ import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
 import com.google.rpc.ErrorInfo;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.protobuf.StatusProto;
+import io.oxia.proto.LeaderHint;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -61,6 +63,40 @@ class OxiaStatusExceptionTest {
                         Status.UNKNOWN.withDescription("node is not leader for shard 1").asRuntimeException());
 
         assertThat(error.getStatusCode()).isEqualTo(OxiaStatusCode.NODE_IS_NOT_LEADER);
+        assertThat(error.isRetryable()).isTrue();
+    }
+
+    @Test
+    void convertsLegacy016LeaderHintDetail() {
+        final var leaderHint = new LeaderHint().setShard(1).setLeaderAddress("server-1:6648");
+        final var grpcStatus =
+                com.google.rpc.Status.newBuilder()
+                        .setCode(106)
+                        .setMessage("node is not leader for shard 1")
+                        .addDetails(
+                                Any.newBuilder()
+                                        .setTypeUrl("type.googleapis.com/io.oxia.proto.v1.LeaderHint")
+                                        .setValue(ByteString.copyFrom(leaderHint.toByteArray())))
+                        .build();
+        final var trailers = new Metadata();
+        trailers.put(
+                Metadata.Key.of(
+                        "grpc-status-details-bin",
+                        ProtoUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance())),
+                grpcStatus);
+
+        final var error =
+                OxiaStatusException.from(
+                        Status.fromCodeValue(grpcStatus.getCode())
+                                .withDescription("node is not leader for shard 1")
+                                .asRuntimeException(trailers));
+
+        assertThat(error.getStatusCode()).isEqualTo(OxiaStatusCode.NODE_IS_NOT_LEADER);
+        assertThat(error.getMetadata())
+                .containsEntry("shard", "1")
+                .containsEntry("leader", "server-1:6648");
+        assertThat(error.getLeaderHint(1)).contains("server-1:6648");
+        assertThat(error.getLeaderHint(2)).isEmpty();
         assertThat(error.isRetryable()).isTrue();
     }
 


### PR DESCRIPTION
## Motivation

The Java client supports shard-leader redirects from the `google.rpc.ErrorInfo` metadata used by Oxia 0.17.0 and newer. Oxia 0.16.x instead returns custom gRPC status code `106` with an `io.oxia.proto.v1.LeaderHint` protobuf detail.

gRPC Java normalizes code `106` to `UNKNOWN` and rejects the rich status because the normalized code no longer matches the status-details trailer. As a result, the client cannot see the leader hint and can keep retrying a stale cached leader after a failover.

## Modifications

- Add the legacy `LeaderHint` message with the same wire fields used by Oxia 0.16.x.
- Introduce an ordered status-decoder strategy for the legacy 0.16.x and standard 0.17.x wire formats.
- Decode custom code `106` and `LeaderHint` directly into an `OxiaStatusException` in `LegacyLeaderHintStatusDecoder`.
- Keep validated gRPC status, `ErrorInfo`, standard-code, and message fallback handling in `StandardGrpcStatusDecoder`.
- Return `UNKNOWN` when a decoder does not recognize the error so `OxiaStatusException` can continue to the next strategy without an intermediate result or `Optional`.

## Testing

- `./gradlew :client:spotlessCheck`
- `./gradlew :client:spotbugsMain`
- `./gradlew :client:test --tests "*Test"`
- `./gradlew :client:test --tests io.oxia.client.grpc.OxiaStatusExceptionTest --tests io.oxia.client.grpc.GrpcRpcProviderTest`