### PR TITLE
fix: support legacy token authentication class name

### DIFF
--- a/client/src/main/java/io/oxia/client/auth/AuthenticationFactory.java
+++ b/client/src/main/java/io/oxia/client/auth/AuthenticationFactory.java
@@ -22,11 +22,18 @@ import java.lang.reflect.Constructor;
 
 public class AuthenticationFactory {
 
+    private static final String LEGACY_TOKEN_AUTHENTICATION_CLASS_NAME =
+            "io.streamnative.oxia.client.auth.TokenAuthentication";
+
     public static Authentication create(String authPluginClassName, String authParamsString)
             throws UnsupportedAuthenticationException {
         try {
             if (!Strings.isNullOrEmpty(authPluginClassName)) {
-                Class<?> authClass = Class.forName(authPluginClassName);
+                String resolvedClassName =
+                        LEGACY_TOKEN_AUTHENTICATION_CLASS_NAME.equals(authPluginClassName)
+                                ? TokenAuthentication.class.getName()
+                                : authPluginClassName;
+                Class<?> authClass = Class.forName(resolvedClassName);
                 Constructor<?> declaredConstructor = authClass.getDeclaredConstructor();
                 declaredConstructor.setAccessible(true);
                 Authentication auth = (Authentication) declaredConstructor.newInstance();

--- a/client/src/test/java/io/oxia/client/auth/TokenAuthenticationTest.java
+++ b/client/src/test/java/io/oxia/client/auth/TokenAuthenticationTest.java
@@ -45,6 +45,16 @@ public class TokenAuthenticationTest {
     }
 
     @Test
+    void testLegacyTokenAuthenticationClassName() throws Exception {
+        Authentication authentication =
+                AuthenticationFactory.create(
+                        "io.streamnative.oxia.client.auth.TokenAuthentication", "token:1234");
+
+        assertThat(authentication).isInstanceOf(TokenAuthentication.class);
+        assertThat(authentication.generateCredentials()).containsEntry("Authorization", "Bearer 1234");
+    }
+
+    @Test
     void testTokenAuthenticationConfigure() throws Exception {
         Class<?> authClass = TokenAuthentication.class;
         Constructor<?> declaredConstructor = authClass.getDeclaredConstructor();


### PR DESCRIPTION
## Motivation
Existing client configurations may still specify `io.streamnative.oxia.client.auth.TokenAuthentication`. Since authentication plugins are loaded by fully qualified class name, the package rename to `io.oxia.client.auth.TokenAuthentication` causes those configurations to fail at runtime.

## Modifications
- Resolve the legacy token authentication class name to the current implementation.
- Add regression coverage for loading and configuring token authentication through the legacy name.

## Testing
- `./gradlew :client:spotlessApply :client:test --tests io.oxia.client.auth.TokenAuthenticationTest`
- `./gradlew build` (348 client tests ran; six Docker-backed integration tests could not initialize because Docker is unavailable in the local environment.)