### PR TITLE
chore: release 0.9.6-rc.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.oxia-db
-version=0.9.5
+version=0.9.6-rc.1
 
 org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true


### PR DESCRIPTION
## Motivation

Publish the first 0.9.6 release candidate so the Oxia 0.16.x leader-hint compatibility fix can be tested before the final 0.9.6 release.

## Modifications

- Bump the project version from `0.9.5` to `0.9.6-rc.1`.
- Include legacy Oxia 0.16.x `LeaderHint` decoding from #373.

## Testing

- `./gradlew spotlessCheck :client-api:compileJava :client:compileJava --no-daemon`